### PR TITLE
Bugfix/specific mindex

### DIFF
--- a/_aicspylibczi/Image.h
+++ b/_aicspylibczi/Image.h
@@ -95,13 +95,20 @@ namespace pylibczi {
           });
       }
 
+      std::vector< std::map<char, size_t> >
+      getImageDimsList(){
+          std::vector< std::map<char, size_t> > indexMap;
+          for (const auto& image : *this) {
+              indexMap.push_back(image->getValidIndexes(m_isMosaic)); // only add M if it's a mosaic file
+          }
+          return indexMap;
+      }
+
 
       std::vector<std::pair<char, size_t> >
       getShape(){
-          std::vector< std::map<char, int> > validIndexes;
-          for (const auto& image : *this) {
-              validIndexes.push_back(image->getValidIndexes(m_isMosaic)); // only add M if it's a mosaic file
-          }
+
+          std::vector< std::map<char, size_t> > validIndexes = getImageDimsList();
 
           // TODO This code assumes the data is a matrix, meaning for example scene's have the same number of Z-slices
           // TODO is there another way to do this that could cope with variable data sizes within the matrix?
@@ -122,7 +129,7 @@ namespace pylibczi {
           charSizes.emplace_back('Y', heightByWidth[hByWsize - 2]); // H: 2 - 2 = 0 | 3 - 2 = 1
           charSizes.emplace_back('X', heightByWidth[hByWsize - 1]); // W: 2 - 1 = 1 | 3 - 1 = 2
           // sort them into decending DimensionIndex Order
-          std::sort(charSizes.begin(), charSizes.end(), [&](std::pair<char, int> a_, std::pair<char, int> b_){
+          std::sort(charSizes.begin(), charSizes.end(), [&](std::pair<char, size_t> a_, std::pair<char, size_t> b_){
               return libCZI::Utils::CharToDimension(a_.first) > libCZI::Utils::CharToDimension(b_.first);
           });
           return charSizes;

--- a/_aicspylibczi/Reader.cpp
+++ b/_aicspylibczi/Reader.cpp
@@ -79,8 +79,7 @@ namespace pylibczi {
   std::vector<int>
   Reader::dimSizes()
   {
-      std:
-      string dString = dimsString();
+      std::string dString = dimsString();
       if (m_specifyScene) return std::vector<int>(dString.size(), -1);
 
       DimIndexRangeMap tbl;

--- a/_aicspylibczi/Reader.cpp
+++ b/_aicspylibczi/Reader.cpp
@@ -322,6 +322,8 @@ namespace pylibczi {
   void
   Reader::addOrderMapping()
   {
+      bool firstGo = true;
+      bool inconsistent = false;
       // create a reference for finding one or more subblock indices from a CDimCoordinate
       m_czireader->EnumerateSubBlocks([&](int index_, const libCZI::SubBlockInfo& info_) -> bool {
           if (isPyramid0(info_)) {
@@ -329,6 +331,14 @@ namespace pylibczi {
                   std::make_tuple(&(info_.coordinate), info_.mIndex, isMosaic()),
                   std::make_tuple(index_)
               );
+              if( firstGo ) m_pixelType = info_.pixelType;
+              else if( m_pixelType != info_.pixelType ){
+                  if(!inconsistent) {
+                      std::cout << "warning CZI file contains inconsistent pixel types" << std::endl;
+                      inconsistent = true;
+                  }
+                  m_pixelType = libCZI::PixelType::Invalid;
+              }
           }
           return true;
       });

--- a/_aicspylibczi/Reader.cpp
+++ b/_aicspylibczi/Reader.cpp
@@ -241,7 +241,6 @@ namespace pylibczi {
       for_each(matches.begin(), matches.end(), [&](const SubblockIndexVec::value_type& match_) {
           auto subblock = m_czireader->ReadSubBlock(match_.second);
           const libCZI::SubBlockInfo& info = subblock->GetSubBlockInfo();
-          std::cout << "mIndex: " << info.mIndex << std::endl;
           auto image = ImageFactory::constructImage(subblock->CreateBitmap(),
               &info.coordinate, info.logicalRect, info.mIndex);
           // This was conditional on split_bgr_ but that's a bad idea so I'm removing it.

--- a/_aicspylibczi/Reader.cpp
+++ b/_aicspylibczi/Reader.cpp
@@ -241,6 +241,7 @@ namespace pylibczi {
       for_each(matches.begin(), matches.end(), [&](const SubblockIndexVec::value_type& match_) {
           auto subblock = m_czireader->ReadSubBlock(match_.second);
           const libCZI::SubBlockInfo& info = subblock->GetSubBlockInfo();
+          std::cout << "mIndex: " << info.mIndex << std::endl;
           auto image = ImageFactory::constructImage(subblock->CreateBitmap(),
               &info.coordinate, info.logicalRect, info.mIndex);
           // This was conditional on split_bgr_ but that's a bad idea so I'm removing it.

--- a/_aicspylibczi/Reader.h
+++ b/_aicspylibczi/Reader.h
@@ -84,6 +84,7 @@ namespace pylibczi {
       std::shared_ptr<CCZIReader> m_czireader; // required for cast in libCZI
       libCZI::SubBlockStatistics m_statistics;
       std::vector<std::pair<SubblockSortable, int> > m_orderMapping;
+      libCZI::PixelType m_pixelType;
       bool m_specifyScene;
 
   public:
@@ -268,7 +269,10 @@ namespace pylibczi {
        */
       libCZI::IntRect getSceneYXSize(int scene_index_ = -1);
 
-      // libCZI::PixelType pixelType() const { auto ans = libCZI::Utils::PixelTypeToInformalString( )}
+      std::string pixelType() const {
+          // each subblock can apparently have a different pixelType 🙄
+          return libCZI::Utils::PixelTypeToInformalString(m_pixelType);
+      }
 
   private:
 

--- a/_aicspylibczi/SubblockMetaVec.h
+++ b/_aicspylibczi/SubblockMetaVec.h
@@ -45,21 +45,21 @@ namespace pylibczi {
           });
       }
 
-      std::vector<std::pair<char, int> >
+      std::vector<std::pair<char, size_t> >
       getShape(){
-          std::vector< std::map<char, int> > validIndexes;
+          std::vector< std::map<char, size_t> > validIndexes;
           for (const auto& image : *this) {
               validIndexes.push_back(image.getValidIndexes(m_isMosaic)); // only add M if it's a mosaic file
           }
 
           // TODO This code assumes the data is a matrix, meaning for example scene's have the same number of Z-slices
           // TODO is there another way to do this that could cope with variable data sizes within the matrix?
-          std::vector<std::pair<char, int> > charSizes;
-          std::map<char, std::set<int> > charSetSize;
-          std::map<char, std::set<int> >::iterator found;
+          std::vector<std::pair<char, size_t> > charSizes;
+          std::map<char, std::set<size_t> > charSetSize;
+          std::map<char, std::set<size_t> >::iterator found;
           for( const auto& validMap : validIndexes){
               for( auto keySet : validMap) {
-                  found = charSetSize.emplace(keySet.first, std::set<int>()).first;
+                  found = charSetSize.emplace(keySet.first, std::set<size_t>()).first;
                   found->second.insert(keySet.second);
               }
           }
@@ -67,7 +67,7 @@ namespace pylibczi {
               charSizes.emplace_back(keySet.first, keySet.second.size());
           }
           // sort them into descending DimensionIndex Order
-          std::sort(charSizes.begin(), charSizes.end(), [&](std::pair<char, int> a_, std::pair<char, int> b_){
+          std::sort(charSizes.begin(), charSizes.end(), [&](std::pair<char, size_t> a_, std::pair<char, size_t> b_){
               return libCZI::Utils::CharToDimension(a_.first) > libCZI::Utils::CharToDimension(b_.first);
           });
           return charSizes;

--- a/_aicspylibczi/SubblockSortable.h
+++ b/_aicspylibczi/SubblockSortable.h
@@ -22,13 +22,13 @@ namespace pylibczi{
 
       int mIndex() const { return m_indexM; }
 
-      std::map<char, int>  getDimsAsChars() const {
+      std::map<char, size_t>  getDimsAsChars() const {
           return SubblockSortable::getValidIndexes(m_planeCoordinate, m_indexM, m_isMosaic);
       }
 
-      static std::map<char, int> getValidIndexes(const libCZI::CDimCoordinate& planecoord_, int index_m_, bool is_mosaic_=false)
+      static std::map<char, size_t> getValidIndexes(const libCZI::CDimCoordinate& planecoord_, int index_m_, bool is_mosaic_=false)
       {
-          std::map<char, int> ans;
+          std::map<char, size_t> ans;
           for (auto di : Constants::s_sortOrder) {
               int value;
               if (planecoord_.TryGetPosition(di, &value)) ans.emplace(libCZI::Utils::DimensionToChar(di), value);
@@ -37,7 +37,7 @@ namespace pylibczi{
           return ans;
       }
 
-      std::map<char, int> getValidIndexes(bool is_mosaic_ = false) const {
+      std::map<char, size_t> getValidIndexes(bool is_mosaic_ = false) const {
           return SubblockSortable::getValidIndexes(m_planeCoordinate, m_indexM, is_mosaic_);
       }
 

--- a/_aicspylibczi/SubblockSortable.h
+++ b/_aicspylibczi/SubblockSortable.h
@@ -42,9 +42,7 @@ namespace pylibczi{
       }
 
       bool operator<(const SubblockSortable& other_) const {
-          if(!m_isMosaic)
-              return SubblockSortable::aLessThanB(m_planeCoordinate, other_.m_planeCoordinate);
-          if( m_indexM != -1 || other_.m_indexM != -1)
+          if(!m_isMosaic || m_indexM == -1 || other_.m_indexM == -1)
               return SubblockSortable::aLessThanB(m_planeCoordinate, other_.m_planeCoordinate);
           return SubblockSortable::aLessThanB(m_planeCoordinate, m_indexM, other_.m_planeCoordinate, other_.m_indexM);
       }

--- a/_aicspylibczi/pb_bindings.cpp
+++ b/_aicspylibczi/pb_bindings.cpp
@@ -44,7 +44,8 @@ PYBIND11_MODULE(_aicspylibczi, m)
         .def("read_selected", &pylibczi::Reader::readSelected)
         .def("mosaic_shape", &pylibczi::Reader::mosaicShape)
         .def("read_meta_from_subblock", &pylibczi::Reader::readSubblockMeta)
-        .def("read_mosaic", &pylibczi::Reader::readMosaic);
+        .def("read_mosaic", &pylibczi::Reader::readMosaic)
+        .def("pixelType", &pylibczi::Reader::pixelType);
 
     py::class_<pylibczi::IndexMap>(m, "IndexMap")
         .def(py::init<>())

--- a/_aicspylibczi/pb_bindings.cpp
+++ b/_aicspylibczi/pb_bindings.cpp
@@ -45,7 +45,7 @@ PYBIND11_MODULE(_aicspylibczi, m)
         .def("mosaic_shape", &pylibczi::Reader::mosaicShape)
         .def("read_meta_from_subblock", &pylibczi::Reader::readSubblockMeta)
         .def("read_mosaic", &pylibczi::Reader::readMosaic)
-        .def("pixelType", &pylibczi::Reader::pixelType);
+        .def("pixel_type", &pylibczi::Reader::pixelType);
 
     py::class_<pylibczi::IndexMap>(m, "IndexMap")
         .def(py::init<>())

--- a/aicspylibczi/CziFile.py
+++ b/aicspylibczi/CziFile.py
@@ -109,6 +109,17 @@ class CziFile(object):
         """
         return self.reader.read_dims()
 
+    @property
+    def pixel_type(self):
+        """
+        The pixelType of the images. If the pixelType is different in the different subblocks it returns Invalid.
+
+        Returns
+        -------
+        A string containing the name of the type of each pixel. If inconsistent it returns invalid.
+        """
+        return self.reader.pixelType()
+
     def scene_bounding_box(self, index: int = -1):
         """
         Get the bounding box of the raw collected data (pyramid 0) from the czifile. if not specified it defaults to

--- a/aicspylibczi/CziFile.py
+++ b/aicspylibczi/CziFile.py
@@ -302,6 +302,11 @@ class CziFile(object):
             [('S', 1), ('T', 1), ('C', 2), ('Z', 25), ('Y', 1024), ('X', 1024)]
             so if you probed the numpy.ndarray with .shape you would get (1, 1, 2, 25, 1024, 1024).
 
+        Notes
+        -----
+        The M Dimension is a representation of the m_index used inside libCZI. Unfortunately this can be sparsely
+        packed for a given selection which causes problems when indexing memory. Consequently the M Dimension may
+        not match the m_index that is being used in libCZI or displayed in Zeiss' Zen software.
         """
         plane_constraints = self.czilib.DimCoord()
         [plane_constraints.set_dim(k, v) for (k, v) in kwargs.items() if k in CziFile.ZISRAW_DIMS]

--- a/aicspylibczi/CziFile.py
+++ b/aicspylibczi/CziFile.py
@@ -118,7 +118,7 @@ class CziFile(object):
         -------
         A string containing the name of the type of each pixel. If inconsistent it returns invalid.
         """
-        return self.reader.pixelType()
+        return self.reader.pixel_type()
 
     def scene_bounding_box(self, index: int = -1):
         """

--- a/aicspylibczi/tests/test_czi_file.py
+++ b/aicspylibczi/tests/test_czi_file.py
@@ -146,6 +146,15 @@ def test_read_image(data_dir, fname, expected):
     assert img.shape == expected
 
 
+@pytest.mark.parametrize("fname, args, expected", [
+    ('mosaic_test.czi', {'M': 0}, (1, 1, 1, 1, 1, 624, 924))
+])
+def test_read_image_args(data_dir, fname, args, expected):
+    czi = CziFile(data_dir / fname)
+    img, shp = czi.read_image(**args)
+    assert img.shape == expected
+
+
 @pytest.mark.parametrize("fname, exp_str, exp_dict", [
     ('s_1_t_1_c_1_z_1.czi', "BCYX", [{'B': (0, 1), 'C': (0, 1), 'X': (0, 475), 'Y': (0, 325)}]),
     ('s_3_t_1_c_3_z_5.czi', "BSCZYX", [{'B': (0, 1), 'C': (0, 3), 'X': (0, 475), 'Y': (0, 325),

--- a/aicspylibczi/tests/test_czi_file.py
+++ b/aicspylibczi/tests/test_czi_file.py
@@ -146,6 +146,18 @@ def test_read_image(data_dir, fname, expected):
     assert img.shape == expected
 
 
+@pytest.mark.parametrize("fname, expected", [
+    ('s_1_t_1_c_1_z_1.czi', "gray16"),
+    ('s_3_t_1_c_3_z_5.czi', "gray16"),
+    ('mosaic_test.czi', 'gray16'),
+    ('RGB-8bit.czi', 'bgr24'),
+])
+def test_pixel_type(data_dir, fname, expected):
+    czi = CziFile(str(data_dir / fname))
+    pix_type = czi.pixel_type
+    assert pix_type == expected
+
+
 @pytest.mark.parametrize("fname, args, expected", [
     ('mosaic_test.czi', {'M': 0}, (1, 1, 1, 1, 1, 624, 924))
 ])


### PR DESCRIPTION
fixes #34 

There was a bug in the compare operator that had the consequence that if M was specified it ignored it. 
The changes here address that issue so that one can select specific M dimensions values.

pixel_type was added as a property so that an image can be queried.

- changes implemented 
- tests added for  new functionality
- documentation extended