### PR TITLE
Feature/unified xml

### DIFF
--- a/aicspylibczi/CziFile.py
+++ b/aicspylibczi/CziFile.py
@@ -278,7 +278,8 @@ class CziFile(object):
         root = etree.Element("Subblocks")
         for pair in subblock_meta:
             new_element = etree.Element("Subblock")
-            (new_element.set(dim, str(number)) for dim, number in pair[0].items())
+            for dim, number in pair[0].items():
+                new_element.set(dim, str(number))
             new_element.append(etree.XML(pair[1]))
             root.append(new_element)
         return root

--- a/aicspylibczi/CziFile.py
+++ b/aicspylibczi/CziFile.py
@@ -266,8 +266,8 @@ class CziFile(object):
         -------
         [(dict, str)] if unified_xml is False
             an array of tuples containing a dimension dictionary and the corresponding subblock metadata
-        str if unified_xml is True
-            an lxml document containing the requested subblock metadata as a string.
+        lxml.etree.Element if unified_xml is True
+            an lxml document containing the requested subblock metadata.
         """
         plane_constraints = self.czilib.DimCoord()
         [plane_constraints.set_dim(k, v) for (k, v) in kwargs.items() if k in CziFile.ZISRAW_DIMS]
@@ -284,7 +284,7 @@ class CziFile(object):
                 new_element.set('S', "0")
             new_element.append(etree.XML(pair[1]))
             root.append(new_element)
-        return etree.tostring(root)
+        return root
 
     def read_image(self, **kwargs):
         """

--- a/aicspylibczi/CziFile.py
+++ b/aicspylibczi/CziFile.py
@@ -233,6 +233,8 @@ class CziFile(object):
         if self.meta_root is None:
             meta_str = self.reader.read_meta()
             self.meta_root = etree.fromstring(meta_str)
+            subblock_meta = self.read_subblock_metadata(unified_xml=True)
+            self.meta_root.append(subblock_meta)
 
         if self.metafile_out:
             metastr = etree.tostring(self.meta_root, pretty_print=True).decode('utf-8')

--- a/aicspylibczi/CziFile.py
+++ b/aicspylibczi/CziFile.py
@@ -226,8 +226,8 @@ class CziFile(object):
 
         Returns
         -------
-        lxml.etree
-            metadata as an xml etree
+        str
+            An lxml.etree of the metadata as a string
 
         """
         if self.meta_root is None:

--- a/aicspylibczi/CziFile.py
+++ b/aicspylibczi/CziFile.py
@@ -282,6 +282,8 @@ class CziFile(object):
             new_element = etree.Element("Subblock")
             for dim, number in pair[0].items():
                 new_element.set(dim, str(number))
+            if 'S' not in pair[0]:
+                new_element.set('S', "0")
             new_element.append(etree.XML(pair[1]))
             root.append(new_element)
         return root

--- a/aicspylibczi/CziFile.py
+++ b/aicspylibczi/CziFile.py
@@ -222,7 +222,7 @@ class CziFile(object):
     @property
     def meta(self):
         """
-        Extract all metadata from czifile.
+        Extract the metadata block from the czi file.
 
         Returns
         -------
@@ -233,8 +233,6 @@ class CziFile(object):
         if self.meta_root is None:
             meta_str = self.reader.read_meta()
             self.meta_root = etree.fromstring(meta_str)
-            subblock_meta = self.read_subblock_metadata(unified_xml=True)
-            self.meta_root.append(subblock_meta)
 
         if self.metafile_out:
             metastr = etree.tostring(self.meta_root, pretty_print=True).decode('utf-8')
@@ -268,8 +266,8 @@ class CziFile(object):
         -------
         [(dict, str)] if unified_xml is False
             an array of tuples containing a dimension dictionary and the corresponding subblock metadata
-        lxml.etree.Element if unified_xml is True
-            an lxml document containing the requested metadata
+        str if unified_xml is True
+            an lxml document containing the requested subblock metadata as a string.
         """
         plane_constraints = self.czilib.DimCoord()
         [plane_constraints.set_dim(k, v) for (k, v) in kwargs.items() if k in CziFile.ZISRAW_DIMS]
@@ -286,7 +284,7 @@ class CziFile(object):
                 new_element.set('S', "0")
             new_element.append(etree.XML(pair[1]))
             root.append(new_element)
-        return root
+        return etree.tostring(root)
 
     def read_image(self, **kwargs):
         """

--- a/aicspylibczi/tests/test_czi_file.py
+++ b/aicspylibczi/tests/test_czi_file.py
@@ -221,8 +221,7 @@ def test_read_unified_subblock_meta(data_dir, fname, expected):
     with open(data_dir / fname, 'rb') as fp:
         czi = CziFile(czi_filename=fp)
         data = czi.read_subblock_metadata(unified_xml=True)
-        xml_str = etree.tostring(data)
-        assert expected in xml_str
+        assert expected in data
 
 
 @pytest.mark.parametrize("fname, expects", [

--- a/aicspylibczi/tests/test_czi_file.py
+++ b/aicspylibczi/tests/test_czi_file.py
@@ -1,6 +1,7 @@
 import io
 import numpy as np
 import pytest
+from lxml import etree
 
 from aicspylibczi import CziFile
 from _aicspylibczi import PylibCZI_CDimCoordinatesOverspecifiedException
@@ -201,6 +202,26 @@ def test_read_subblock_meta(data_dir, fname, expected):
         czi = CziFile(czi_filename=fp)
         data = czi.read_subblock_metadata()
         assert expected in data[0][1]
+
+
+@pytest.mark.parametrize("fname, expected", [
+    ('s_1_t_1_c_1_z_1.czi', b'<Subblocks><Subblock><METADATA><Tags><AcquisitionTime>2019-06-27T18:33:41.1154211Z'
+                            b'</AcquisitionTime><DetectorState><CameraState Id=""><CameraDisplayName>Camera 2 Left'
+                            b'</CameraDisplayName><ApplyCameraProfile>false</ApplyCameraProfile><ApplyImageOrientation>'
+                            b'true</ApplyImageOrientation><ExposureTime>10004210.526316</ExposureTime><Frame>'
+                            b'100,376,1900,1300</Frame><ImageOrientation>3</ImageOrientation></CameraState>'
+                            b'</DetectorState><StageXPosition>+000000043427.9820</StageXPosition><StageYPosition>'
+                            b'+000000042720.2960</StageYPosition><FocusPosition>+000000009801.2900</FocusPosition>'
+                            b'<RoiCenterOffsetX>+000000000007.0420</RoiCenterOffsetX><RoiCenterOffsetY>'
+                            b'+000000000000.5420</RoiCenterOffsetY></Tags><DataSchema><ValidBitsPerPixel>16'
+                            b'</ValidBitsPerPixel></DataSchema><AttachmentSchema/></METADATA></Subblock></Subblocks>'),
+])
+def test_read_unified_subblock_meta(data_dir, fname, expected):
+    with open(data_dir / fname, 'rb') as fp:
+        czi = CziFile(czi_filename=fp)
+        data = czi.read_subblock_metadata(unified_xml=True)
+        xml_str = etree.tostring(data)
+        assert expected in xml_str
 
 
 @pytest.mark.parametrize("fname, expects", [

--- a/aicspylibczi/tests/test_czi_file.py
+++ b/aicspylibczi/tests/test_czi_file.py
@@ -205,7 +205,8 @@ def test_read_subblock_meta(data_dir, fname, expected):
 
 
 @pytest.mark.parametrize("fname, expected", [
-    ('s_1_t_1_c_1_z_1.czi', b'<Subblocks><Subblock><METADATA><Tags><AcquisitionTime>2019-06-27T18:33:41.1154211Z'
+    ('s_1_t_1_c_1_z_1.czi', b'<Subblocks><Subblock B="0" C="0"><METADATA><Tags><AcquisitionTime>'
+                            b'2019-06-27T18:33:41.1154211Z'
                             b'</AcquisitionTime><DetectorState><CameraState Id=""><CameraDisplayName>Camera 2 Left'
                             b'</CameraDisplayName><ApplyCameraProfile>false</ApplyCameraProfile><ApplyImageOrientation>'
                             b'true</ApplyImageOrientation><ExposureTime>10004210.526316</ExposureTime><Frame>'

--- a/aicspylibczi/tests/test_czi_file.py
+++ b/aicspylibczi/tests/test_czi_file.py
@@ -205,7 +205,7 @@ def test_read_subblock_meta(data_dir, fname, expected):
 
 
 @pytest.mark.parametrize("fname, expected", [
-    ('s_1_t_1_c_1_z_1.czi', b'<Subblocks><Subblock B="0" C="0"><METADATA><Tags><AcquisitionTime>'
+    ('s_1_t_1_c_1_z_1.czi', b'<Subblocks><Subblock B="0" C="0" S="0"><METADATA><Tags><AcquisitionTime>'
                             b'2019-06-27T18:33:41.1154211Z'
                             b'</AcquisitionTime><DetectorState><CameraState Id=""><CameraDisplayName>Camera 2 Left'
                             b'</CameraDisplayName><ApplyCameraProfile>false</ApplyCameraProfile><ApplyImageOrientation>'

--- a/aicspylibczi/tests/test_czi_file.py
+++ b/aicspylibczi/tests/test_czi_file.py
@@ -1,4 +1,5 @@
 import io
+from lxml import etree
 import numpy as np
 import pytest
 
@@ -220,7 +221,7 @@ def test_read_unified_subblock_meta(data_dir, fname, expected):
     with open(data_dir / fname, 'rb') as fp:
         czi = CziFile(czi_filename=fp)
         data = czi.read_subblock_metadata(unified_xml=True)
-        assert expected in data
+        assert expected in etree.tostring(data)
 
 
 @pytest.mark.parametrize("fname, expects", [

--- a/aicspylibczi/tests/test_czi_file.py
+++ b/aicspylibczi/tests/test_czi_file.py
@@ -1,7 +1,6 @@
 import io
 import numpy as np
 import pytest
-from lxml import etree
 
 from aicspylibczi import CziFile
 from _aicspylibczi import PylibCZI_CDimCoordinatesOverspecifiedException


### PR DESCRIPTION
For the subblock metadata, I added a flag unified_xml which defaults to False. 
When the flag is False the function `read_subblock_metadata(unified_xml=False)` the result is a list of dimension dictionary, XML data string. [behavior unchanged]
When the flag is True the function `read_subblock_metadata(unified_xml=True)` the result is an lxml tree with structure
```xml
<Subblocks>
          <Subblock B="0" C="0">
                      <METADATA>
                                   .....
                      </METADATA>
           </Subblock>
           ...
<Subblocks>
```

This feature was enabled so as to offer a more consistent XML based format rather than a programmatic one. 

I decided to change the `meta` property to include the unified_xml subblock metadata as well as it made more sense to just return it all when the user asks for the metadata.

Question: 
I currently I use the dims that libCZI returns to me with for the sunblock. That results in the following sunblock metadata 
```xml
    <Subblock B="0" C="2" S="0" Z="1">
      <METADATA>
        <Tags>
          <AcquisitionTime>2019-06-27T18:39:27.8980959Z</AcquisitionTime>
          <DetectorState>
            <CameraState Id="">
              <CameraDisplayName>Camera 2 Left</CameraDisplayName>
              <ApplyCameraProfile>false</ApplyCameraProfile>
              <ApplyImageOrientation>true</ApplyImageOrientation>
              <ExposureTime>10004210.526316</ExposureTime>
              <Frame>100,376,1900,1300</Frame>
              <ImageOrientation>3</ImageOrientation>
            </CameraState>
          </DetectorState>
          <StageXPosition>+000000043420.9400</StageXPosition>
          <StageYPosition>+000000038707.5710</StageYPosition>
          <FocusPosition>+000000009800.2900</FocusPosition>
          <RoiCenterOffsetX>+000000000007.0420</RoiCenterOffsetX>
          <RoiCenterOffsetY>+000000000000.5420</RoiCenterOffsetY>
        </Tags>
        <DataSchema>
          <ValidBitsPerPixel>16</ValidBitsPerPixel>
        </DataSchema>
        <AttachmentSchema/>
      </METADATA>
    </Subblock>
```

Should I force these to always be STCZ as a minimal set or just let them omit dimensions, ie `T="0"` is omitted by libCZI and thus the attribute is missing above. Thoughts?