### PR TITLE
Set `czi_filename` in the CziFile constructor

### DIFF
--- a/aicspylibczi/CziFile.py
+++ b/aicspylibczi/CziFile.py
@@ -48,7 +48,6 @@ class CziFile(object):
                  verbose: bool = False):
         # Convert to BytesIO (bytestream)
         self._bytes = self.convert_to_buffer(czi_filename)
-        self.czi_filename = czi_filename
         self.metafile_out = metafile_out
         self.czifile_verbose = verbose
 

--- a/aicspylibczi/CziFile.py
+++ b/aicspylibczi/CziFile.py
@@ -48,7 +48,7 @@ class CziFile(object):
                  verbose: bool = False):
         # Convert to BytesIO (bytestream)
         self._bytes = self.convert_to_buffer(czi_filename)
-        self.czi_filename = None
+        self.czi_filename = czi_filename
         self.metafile_out = metafile_out
         self.czifile_verbose = verbose
 


### PR DESCRIPTION
This sets the `czi_filename` property in the `CziFile` constructor using the corresponding argument, where previously it was always set to `None`. As far as I can tell, this `czi_filename` property isn't set by any side effects elsewhere, so I feel like it should either not exist or get set to a reasonable value.

Unrelated to this change, but seeing as this argument can be more than just a filename (e.g. a buffer) should this argument/property be renamed?