### PR TITLE
Bugfix/speed

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,137 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Mozilla
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: TopLevel
+AlwaysBreakAfterReturnType: TopLevel
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: false
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Mozilla
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeComma
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: false
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+Standard:        Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseCRLF:         false
+UseTab:          Never
+...
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ add_subdirectory(libCZI/Src/libCZI)
 add_subdirectory(pybind11)
 
 include_directories(libCZI/Src)
-find_library(libCZI REQUIRED PATHS ${CMAKE_SOURCE_DIR}/libCZI)
+#find_library(libCZI REQUIRED PATHS ${CMAKE_SOURCE_DIR}/libCZI)
 find_package(pybind11)
 message(STATUS "Found pybind11 v${pybind11_VERSION}: ${pybind11_INCLUDE_DIRS}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(PYLIBCZI_PYBIND11 _aicspylibczi/pb_bindings.cpp _aicspylibczi/pb_helpers.h _
 
 set(TARGET_ONE libczi_c++_extension)
 set(TARGET_TWO _aicspylibczi)
+set(TARGET_THREE profile_me)
 
 set_target_properties(libCZI PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
 add_library(${TARGET_ONE} STATIC ${PYLIBCZI_C_SRC} ${PYLIBCZI_C_SRC_HEADERS})
@@ -63,6 +64,9 @@ add_custom_command(TARGET ${TARGET_TWO} POST_BUILD
         )
 
 add_subdirectory(c_tests)
+
+add_executable(${TARGET_THREE} main.cpp)
+target_link_libraries(${TARGET_THREE} ${TARGET_ONE})
 
 if(DEFINED ENV{BUILD_DOCS})
     add_subdirectory(docs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ set(PYLIBCZI_C_SRC _aicspylibczi/Reader.cpp _aicspylibczi/IndexMap.cpp _aicspyli
         _aicspylibczi/pylibczi_ostream.cpp _aicspylibczi/exceptions.cpp _aicspylibczi/SubblockSortable.h
         _aicspylibczi/pb_caster_SubblockMetaVec.h _aicspylibczi/constants.cpp _aicspylibczi/DimIndex.cpp)
 
-set(PYLIBCZI_PYBIND11 _aicspylibczi/pb_bindings.cpp _aicspylibczi/pb_helpers.h _aicspylibczi/pb_helpers.cpp _aicspylibczi/pb_caster_ImageVector.h
+set(PYLIBCZI_PYBIND11 _aicspylibczi/pb_bindings.cpp _aicspylibczi/pb_helpers.h _aicspylibczi/pb_helpers.cpp _aicspylibczi/pb_caster_ImagesContainer.h
         _aicspylibczi/pb_caster_BytesIO.h _aicspylibczi/pb_caster_libCZI_DimensionIndex.h _aicspylibczi/CSimpleStreamImplFromFd.h
         _aicspylibczi/CSimpleStreamImplFromFd.cpp _aicspylibczi/pb_caster_DimIndex.h)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ add_subdirectory(pybind11)
 
 include_directories(libCZI/Src)
 find_library(libCZI REQUIRED PATHS ${CMAKE_SOURCE_DIR}/libCZI)
+find_package(pybind11)
+message(STATUS "Found pybind11 v${pybind11_VERSION}: ${pybind11_INCLUDE_DIRS}")
 
 set(PYLIBCZI_C_SRC_HEADERS _aicspylibczi/Reader.h _aicspylibczi/helper_algorithms.h _aicspylibczi/exceptions.h _aicspylibczi/inc_libCZI.h
         _aicspylibczi/IndexMap.h _aicspylibczi/Image.h _aicspylibczi/TypedImage.h _aicspylibczi/ImageFactory.h

--- a/_aicspylibczi/DimIndex.cpp
+++ b/_aicspylibczi/DimIndex.cpp
@@ -1,8 +1,9 @@
 #include "DimIndex.h"
 
-namespace pylibczi{
-  char dimIndexToChar(DimIndex index_){
-      switch(index_){
+namespace pylibczi {
+  char dimIndexToChar(DimIndex index_)
+  {
+      switch (index_) {
       case DimIndex::X: return 'X';
       case DimIndex::Y: return 'Y';
       case DimIndex::Z: return 'Z';
@@ -21,29 +22,42 @@ namespace pylibczi{
 
   DimIndex charToDimIndex(char c_)
   {
-      switch (c_)
-      {
-      case 'x':case'X': return DimIndex::X;
-      case 'y':case'Y': return DimIndex::Y;
-      case 'z':case'Z': return DimIndex::Z;
-      case 'c':case'C': return DimIndex::C;
-      case 't':case'T': return DimIndex::T;
-      case 'r':case'R': return DimIndex::R;
-      case 'm':case'M': return DimIndex::M;
-      case 's':case'S': return DimIndex::S;
-      case 'i':case'I': return DimIndex::I;
-      case 'h':case'H': return DimIndex::H;
-      case 'v':case'V': return DimIndex::V;
-      case 'b':case'B': return DimIndex::B;
+      switch (c_) {
+      case 'x':
+      case 'X': return DimIndex::X;
+      case 'y':
+      case 'Y': return DimIndex::Y;
+      case 'z':
+      case 'Z': return DimIndex::Z;
+      case 'c':
+      case 'C': return DimIndex::C;
+      case 't':
+      case 'T': return DimIndex::T;
+      case 'r':
+      case 'R': return DimIndex::R;
+      case 'm':
+      case 'M': return DimIndex::M;
+      case 's':
+      case 'S': return DimIndex::S;
+      case 'i':
+      case 'I': return DimIndex::I;
+      case 'h':
+      case 'H': return DimIndex::H;
+      case 'v':
+      case 'V': return DimIndex::V;
+      case 'b':
+      case 'B': return DimIndex::B;
       default: return DimIndex::invalid;
       }
   }
 
-  libCZI::DimensionIndex dimIndexToDimensionIndex(DimIndex index_){
+  libCZI::DimensionIndex dimIndexToDimensionIndex(DimIndex index_)
+  {
       return libCZI::Utils::CharToDimension(dimIndexToChar(index_));
   }
 
-  DimIndex dimensionIndexToDimIndex(libCZI::DimensionIndex index_){
+  DimIndex dimensionIndexToDimIndex(libCZI::DimensionIndex index_)
+  {
       return charToDimIndex(libCZI::Utils::DimensionToChar(index_));
   }
 

--- a/_aicspylibczi/Image.cpp
+++ b/_aicspylibczi/Image.cpp
@@ -22,23 +22,19 @@ namespace pylibczi {
       {libCZI::PixelType::Gray64Float, typeid(nullptr).name()}     // unsupported by libCZI
   };
 
-std::map<libCZI::PixelType, libCZI::PixelType> Image::s_pixelSplitMap{
-    {libCZI::PixelType::Gray8, libCZI::PixelType::Invalid},
-    {libCZI::PixelType::Gray16, libCZI::PixelType::Invalid},
-    {libCZI::PixelType::Gray32Float, libCZI::PixelType::Invalid},
-    {libCZI::PixelType::Bgr24, libCZI::PixelType::Gray8},
-    {libCZI::PixelType::Bgr48, libCZI::PixelType::Gray16},
-    {libCZI::PixelType::Bgr96Float, libCZI::PixelType::Gray32Float},
-    {libCZI::PixelType::Bgra32, libCZI::PixelType::Invalid},
-    {libCZI::PixelType::Gray64ComplexFloat, libCZI::PixelType::Invalid},
-    {libCZI::PixelType::Bgr192ComplexFloat, libCZI::PixelType::Invalid},
-    {libCZI::PixelType::Gray32, libCZI::PixelType::Invalid},
-    {libCZI::PixelType::Gray64Float, libCZI::PixelType::Invalid}
-};
-
-
-
-
+  std::map<libCZI::PixelType, libCZI::PixelType> Image::s_pixelSplitMap{
+      {libCZI::PixelType::Gray8, libCZI::PixelType::Invalid},
+      {libCZI::PixelType::Gray16, libCZI::PixelType::Invalid},
+      {libCZI::PixelType::Gray32Float, libCZI::PixelType::Invalid},
+      {libCZI::PixelType::Bgr24, libCZI::PixelType::Gray8},
+      {libCZI::PixelType::Bgr48, libCZI::PixelType::Gray16},
+      {libCZI::PixelType::Bgr96Float, libCZI::PixelType::Gray32Float},
+      {libCZI::PixelType::Bgra32, libCZI::PixelType::Invalid},
+      {libCZI::PixelType::Gray64ComplexFloat, libCZI::PixelType::Invalid},
+      {libCZI::PixelType::Bgr192ComplexFloat, libCZI::PixelType::Invalid},
+      {libCZI::PixelType::Gray32, libCZI::PixelType::Invalid},
+      {libCZI::PixelType::Gray64Float, libCZI::PixelType::Invalid}
+  };
 
   size_t Image::calculateIdx(const std::vector<size_t>& indexes_)
   {

--- a/_aicspylibczi/Image.h
+++ b/_aicspylibczi/Image.h
@@ -26,7 +26,7 @@ namespace pylibczi {
    * one subblock which may be either 2D or 3D, in the case of 3D the data is then later split into multiple 2D Image<T> so that
    * the concept of a Channel isn't destroyed.
    */
-  class Image : public SubblockSortable {
+  class Image: public SubblockSortable {
   protected:
       /*!
        * ImageBC holds the data describing the image (Image<T> inherits it). The m_matrixSizes can be 2D or 3D depending on
@@ -60,7 +60,6 @@ namespace pylibczi {
 
       libCZI::IntRect bBox() const { return m_xywh; }
 
-
       size_t length()
       {
           return std::accumulate(m_shape.begin(), m_shape.end(), (size_t) 1, std::multiplies<>());
@@ -70,7 +69,7 @@ namespace pylibczi {
 
       virtual void loadImage(const std::shared_ptr<libCZI::IBitmapData>& bitmap_ptr_, size_t channels_) = 0;
 
-      virtual ~Image() {}
+      virtual ~Image() { }
   };
 
   template<typename T>
@@ -90,48 +89,50 @@ namespace pylibczi {
 
   public:
       void setMosaic(bool val_) { m_isMosaic = val_; }
-      void sort(){
-          std::sort(begin(), end(), [](const std::shared_ptr<Image> &a_, const std::shared_ptr<Image> &b_)->bool{
-              return *a_ < *b_;
+      void sort()
+      {
+          std::sort(begin(), end(), [](const std::shared_ptr<Image>& a_, const std::shared_ptr<Image>& b_) -> bool {
+              return *a_<*b_;
           });
       }
 
-      std::vector< std::map<char, size_t> >
-      getImageDimsList(){
-          std::vector< std::map<char, size_t> > indexMap;
+      std::vector<std::map<char, size_t> >
+      getImageDimsList()
+      {
+          std::vector<std::map<char, size_t> > indexMap;
           for (const auto& image : *this) {
               indexMap.push_back(image->getValidIndexes(m_isMosaic)); // only add M if it's a mosaic file
           }
           return indexMap;
       }
 
-
       std::vector<std::pair<char, size_t> >
-      getShape(){
+      getShape()
+      {
 
-          std::vector< std::map<char, size_t> > validIndexes = getImageDimsList();
+          std::vector<std::map<char, size_t> > validIndexes = getImageDimsList();
 
           // TODO This code assumes the data is a matrix, meaning for example scene's have the same number of Z-slices
           // TODO is there another way to do this that could cope with variable data sizes within the matrix?
           std::vector<std::pair<char, size_t> > charSizes;
           std::map<char, std::set<size_t> > charSetSize;
           std::map<char, std::set<size_t> >::iterator found;
-          for( const auto& validMap : validIndexes){
-              for( auto keySet : validMap) {
+          for (const auto& validMap : validIndexes) {
+              for (auto keySet : validMap) {
                   found = charSetSize.emplace(keySet.first, std::set<size_t>()).first;
                   found->second.insert(keySet.second);
               }
           }
-          for( auto keySet : charSetSize){
+          for (auto keySet : charSetSize) {
               charSizes.emplace_back(keySet.first, keySet.second.size());
           }
           auto heightByWidth = front()->shape(); // assumption: images are the same shape, if not 🙃
           size_t hByWsize = heightByWidth.size();
-          charSizes.emplace_back('Y', heightByWidth[hByWsize - 2]); // H: 2 - 2 = 0 | 3 - 2 = 1
-          charSizes.emplace_back('X', heightByWidth[hByWsize - 1]); // W: 2 - 1 = 1 | 3 - 1 = 2
+          charSizes.emplace_back('Y', heightByWidth[hByWsize-2]); // H: 2 - 2 = 0 | 3 - 2 = 1
+          charSizes.emplace_back('X', heightByWidth[hByWsize-1]); // W: 2 - 1 = 1 | 3 - 1 = 2
           // sort them into decending DimensionIndex Order
-          std::sort(charSizes.begin(), charSizes.end(), [&](std::pair<char, size_t> a_, std::pair<char, size_t> b_){
-              return libCZI::Utils::CharToDimension(a_.first) > libCZI::Utils::CharToDimension(b_.first);
+          std::sort(charSizes.begin(), charSizes.end(), [&](std::pair<char, size_t> a_, std::pair<char, size_t> b_) {
+              return libCZI::Utils::CharToDimension(a_.first)>libCZI::Utils::CharToDimension(b_.first);
           });
           return charSizes;
       }

--- a/_aicspylibczi/Image.h
+++ b/_aicspylibczi/Image.h
@@ -70,6 +70,7 @@ namespace pylibczi {
 
       virtual void loadImage(const std::shared_ptr<libCZI::IBitmapData>& bitmap_ptr_, size_t channels_) = 0;
 
+      virtual ~Image() {}
   };
 
   template<typename T>

--- a/_aicspylibczi/Image.h
+++ b/_aicspylibczi/Image.h
@@ -69,7 +69,7 @@ namespace pylibczi {
 
       virtual void loadImage(const std::shared_ptr<libCZI::IBitmapData>& bitmap_ptr_, size_t channels_) = 0;
 
-      virtual ~Image() { }
+      ~Image() { }
   };
 
   template<typename T>

--- a/_aicspylibczi/ImageFactory.cpp
+++ b/_aicspylibczi/ImageFactory.cpp
@@ -135,9 +135,8 @@ namespace pylibczi {
       if (image==nullptr)
           throw std::bad_alloc();
       image->loadImage(bitmap_ptr_, channels);
-      auto sImage = std::shared_ptr<Image>(image);
-      m_imgContainer->addImage(sImage);
-      return sImage;
+      m_imgContainer->addImage(image);
+      return image;
   }
 
   std::vector< std::pair< char, size_t> >

--- a/_aicspylibczi/ImageFactory.cpp
+++ b/_aicspylibczi/ImageFactory.cpp
@@ -130,7 +130,8 @@ namespace pylibczi {
 
       size_t mem_index = 0;
 
-      std::shared_ptr<Image> image = s_pixelToImageConstructor[pixelType](shape, pixelType, plane_coordinate_, box_,
+      auto imageFactoryFunction = s_pixelToImageConstructor[pixelType];
+      std::shared_ptr<Image> image = imageFactoryFunction(shape, pixelType, plane_coordinate_, box_,
           m_imgContainer.get(), mem_index_, index_m_);
       if (image==nullptr)
           throw std::bad_alloc();

--- a/_aicspylibczi/ImageFactory.cpp
+++ b/_aicspylibczi/ImageFactory.cpp
@@ -18,23 +18,23 @@ namespace pylibczi {
        [](std::vector<size_t> shape_, PixelType pixel_type_, const libCZI::CDimCoordinate* plane_coordinate_, libCZI::IntRect box_,
            ImagesContainerBase* bptr, size_t mem_index_, int index_m_) {
            auto typedPtr = bptr->getBaseAsTyped<uint8_t>();
-           return std::shared_ptr<TypedImage<uint8_t>>( new TypedImage<uint8_t>(std::move(shape_), PixelType::Gray8,
-                   plane_coordinate_, box_, typedPtr->getPointerAtIndex(mem_index_), index_m_
-                   ));
+           return std::shared_ptr<TypedImage<uint8_t>>(new TypedImage<uint8_t>(std::move(shape_), PixelType::Gray8,
+               plane_coordinate_, box_, typedPtr->getPointerAtIndex(mem_index_), index_m_
+           ));
        }},
       {PixelType::Gray16,
        [](std::vector<size_t> shape_, PixelType pixel_type_, const libCZI::CDimCoordinate* plane_coordinate_, libCZI::IntRect box_,
            ImagesContainerBase* bptr, size_t mem_index_, int index_m_) {
            auto typedPtr = bptr->getBaseAsTyped<uint16_t>();
-           return std::shared_ptr<TypedImage<uint16_t>>( new TypedImage<uint16_t>(std::move(shape_), pixel_type_,
-                   plane_coordinate_, box_, typedPtr->getPointerAtIndex(mem_index_), index_m_
-                   ));
+           return std::shared_ptr<TypedImage<uint16_t>>(new TypedImage<uint16_t>(std::move(shape_), pixel_type_,
+               plane_coordinate_, box_, typedPtr->getPointerAtIndex(mem_index_), index_m_
+           ));
        }},
       {PixelType::Gray32,
        [](std::vector<size_t> shape_, PixelType pixel_type_, const libCZI::CDimCoordinate* plane_coordinate_, libCZI::IntRect box_,
            ImagesContainerBase* bptr, size_t mem_index_, int index_m_) {
            auto typedPtr = bptr->getBaseAsTyped<uint32_t>();
-           return std::shared_ptr<TypedImage<uint32_t>>( new TypedImage<uint32_t>(std::move(shape_), pixel_type_,
+           return std::shared_ptr<TypedImage<uint32_t>>(new TypedImage<uint32_t>(std::move(shape_), pixel_type_,
                plane_coordinate_, box_, typedPtr->getPointerAtIndex(mem_index_), index_m_
            ));
        }},
@@ -42,25 +42,25 @@ namespace pylibczi {
        [](std::vector<size_t> shape_, PixelType pixel_type_, const libCZI::CDimCoordinate* plane_coordinate_, libCZI::IntRect box_,
            ImagesContainerBase* bptr, size_t mem_index_, int index_m_) {
            auto typedPtr = bptr->getBaseAsTyped<uint16_t>();
-           return std::shared_ptr<TypedImage<uint16_t>>( new TypedImage<uint16_t>(std::move(shape_), PixelType::Gray16,
-                   plane_coordinate_, box_, typedPtr->getPointerAtIndex(mem_index_), index_m_
-                   ));
+           return std::shared_ptr<TypedImage<uint16_t>>(new TypedImage<uint16_t>(std::move(shape_), PixelType::Gray16,
+               plane_coordinate_, box_, typedPtr->getPointerAtIndex(mem_index_), index_m_
+           ));
        }},
       {PixelType::Gray32Float,
        [](std::vector<size_t> shape_, PixelType pixel_type_, const libCZI::CDimCoordinate* plane_coordinate_, libCZI::IntRect box_,
            ImagesContainerBase* bptr, size_t mem_index_, int index_m_) {
            auto typedPtr = bptr->getBaseAsTyped<float>();
-           return std::shared_ptr<TypedImage<float>>( new TypedImage<float>(std::move(shape_), pixel_type_,
+           return std::shared_ptr<TypedImage<float>>(new TypedImage<float>(std::move(shape_), pixel_type_,
                plane_coordinate_, box_, typedPtr->getPointerAtIndex(mem_index_), index_m_
-               ));
+           ));
        }},
       {PixelType::Bgr96Float,
        [](std::vector<size_t> shape_, PixelType pixel_type_, const libCZI::CDimCoordinate* plane_coordinate_, libCZI::IntRect box_,
            ImagesContainerBase* bptr, size_t mem_index_, int index_m_) {
            auto typedPtr = bptr->getBaseAsTyped<float>();
-           return std::shared_ptr<TypedImage<float>>( new TypedImage<float>(std::move(shape_), PixelType::Gray32Float,
+           return std::shared_ptr<TypedImage<float>>(new TypedImage<float>(std::move(shape_), PixelType::Gray32Float,
                plane_coordinate_, box_, typedPtr->getPointerAtIndex(mem_index_), index_m_
-               ));
+           ));
        }}
   };
 
@@ -122,8 +122,9 @@ namespace pylibczi {
       return image;
   }
 
-  std::vector< std::pair< char, size_t> >
-  ImageFactory::getFixedShape(void){
+  std::vector<std::pair<char, size_t> >
+  ImageFactory::getFixedShape(void)
+  {
       /*!
        * @brief In order to deal with the BGR images in a way that doesn't cause bad API behavior the solution I landed
        * upon was to use the CZI dims. What I mean by this is that if queried about the shape of a BGR image treat the
@@ -137,13 +138,13 @@ namespace pylibczi {
       auto images = m_imgContainer->images();
       images.sort();
       auto charSizes = images.getShape();
-      if( m_imgContainer->pixelType() == libCZI::PixelType::Bgr24 ||
-          m_imgContainer->pixelType() == libCZI::PixelType::Bgr48 ||
-          m_imgContainer->pixelType() == libCZI::PixelType::Bgr96Float ){
-          auto ittr = find_if(charSizes.begin(), charSizes.end(), [](std::pair<char, size_t> &pr){
-              return (pr.first == 'C');
+      if (m_imgContainer->pixelType()==libCZI::PixelType::Bgr24 ||
+          m_imgContainer->pixelType()==libCZI::PixelType::Bgr48 ||
+          m_imgContainer->pixelType()==libCZI::PixelType::Bgr96Float) {
+          auto ittr = find_if(charSizes.begin(), charSizes.end(), [](std::pair<char, size_t>& pr) {
+              return (pr.first=='C');
           });
-          if( ittr != charSizes.end()) ittr->second *=3; // scale the C channel by 3 because we're expanding it
+          if (ittr!=charSizes.end()) ittr->second *= 3; // scale the C channel by 3 because we're expanding it
           else { // There's an implicit C channel so add it and set it to 3
               charSizes.push_back(std::pair<char, size_t>('C', 3));
               std::sort(charSizes.begin(), charSizes.end(), [&](std::pair<char, size_t> a_, std::pair<char, size_t> b_) {

--- a/_aicspylibczi/ImageFactory.cpp
+++ b/_aicspylibczi/ImageFactory.cpp
@@ -64,24 +64,6 @@ namespace pylibczi {
        }}
   };
 
-//  ImageFactory::SplitCtorMap ImageFactory::s_pixelToSplit{
-//      {PixelType::Bgr24,
-//       [](std::shared_ptr<Image> img_, int channel_) {
-//           return std::shared_ptr<TypedImage<uint8_t>>(
-//               new TypedImage<uint8_t>(ImageFactory::getDerived<uint8_t>(img_), libCZI::PixelType::Gray8, channel_));
-//       }},
-//      {PixelType::Bgr48,
-//       [](std::shared_ptr<Image> img_, int channel_) {
-//           return std::shared_ptr<TypedImage<uint16_t>>(
-//               new TypedImage<uint16_t>(ImageFactory::getDerived<uint16_t>(img_), libCZI::PixelType::Gray16, channel_));
-//       }},
-//      {PixelType::Bgr96Float,
-//       [](std::shared_ptr<Image> img_, int channel_) {
-//           return std::shared_ptr<TypedImage<float>>(
-//               new TypedImage<float>(ImageFactory::getDerived<float>(img_), libCZI::PixelType::Gray32Float, channel_));
-//       }}
-//  };
-
   size_t
   ImageFactory::sizeOfPixelType(PixelType pixel_type_)
   {

--- a/_aicspylibczi/ImageFactory.cpp
+++ b/_aicspylibczi/ImageFactory.cpp
@@ -140,4 +140,25 @@ namespace pylibczi {
       return sImage;
   }
 
+  std::vector< std::pair< char, size_t> >
+  ImageFactory::getFixedShape(void){
+      auto images = m_imgContainer->images();
+      images.sort();
+      auto charSizes = images.getShape();
+      if( m_imgContainer->pixelType() == libCZI::PixelType::Bgr24 ||
+          m_imgContainer->pixelType() == libCZI::PixelType::Bgr48 ||
+          m_imgContainer->pixelType() == libCZI::PixelType::Bgr96Float ){
+          auto ittr = find_if(charSizes.begin(), charSizes.end(), [](std::pair<char, size_t> &pr){
+              return (pr.first == 'C');
+          });
+          if( ittr != charSizes.end()) ittr->second *=3;
+          else {
+              charSizes.push_back(std::pair<char, size_t>('C', 3));
+              std::sort(charSizes.begin(), charSizes.end(), [&](std::pair<char, size_t> a_, std::pair<char, size_t> b_) {
+                  return libCZI::Utils::CharToDimension(a_.first)>libCZI::Utils::CharToDimension(b_.first);
+              });
+          }
+      }
+      return charSizes;
+  }
 }

--- a/_aicspylibczi/ImageFactory.cpp
+++ b/_aicspylibczi/ImageFactory.cpp
@@ -1,4 +1,6 @@
 #include "ImageFactory.h"
+
+#include <memory>
 #include "TypedImage.h"
 
 namespace pylibczi {
@@ -6,39 +8,51 @@ namespace pylibczi {
   ImageFactory::CtorMap ImageFactory::s_pixelToImage{
       {PixelType::Gray8,
        [](std::vector<size_t> shape_, PixelType pixel_type_, const libCZI::CDimCoordinate* plane_coordinate_, libCZI::IntRect box_,
-           int index_m_) {
-           return std::shared_ptr<TypedImage<uint8_t>>(
-               new TypedImage<uint8_t>(std::move(shape_), pixel_type_, plane_coordinate_, box_, index_m_));
+           ImagesContainerBase* bptr, size_t mem_index_, int index_m_) {
+           auto typedPtr = bptr->getBaseAsTyped<uint8_t>();
+           return std::shared_ptr<TypedImage<uint8_t>>(new TypedImage<uint8_t>(std::move(shape_), pixel_type_,
+               plane_coordinate_, box_, typedPtr->getPointerAtIndex(mem_index_), index_m_
+           ));
        }},
       {PixelType::Bgr24,
        [](std::vector<size_t> shape_, PixelType pixel_type_, const libCZI::CDimCoordinate* plane_coordinate_, libCZI::IntRect box_,
-           int index_m_) {
-           return std::shared_ptr<TypedImage<uint8_t>>(
-               new TypedImage<uint8_t>(std::move(shape_), pixel_type_, plane_coordinate_, box_, index_m_));
+           ImagesContainerBase* bptr, size_t mem_index_, int index_m_) {
+           auto typedPtr = bptr->getBaseAsTyped<uint8_t>();
+           return std::shared_ptr<TypedImage<uint8_t>>( new TypedImage<uint8_t>(std::move(shape_), pixel_type_,
+                   plane_coordinate_, box_, typedPtr->getPointerAtIndex(mem_index_), index_m_
+                   ));
        }},
       {PixelType::Gray16,
        [](std::vector<size_t> shape_, PixelType pixel_type_, const libCZI::CDimCoordinate* plane_coordinate_, libCZI::IntRect box_,
-           int index_m_) {
-           return std::shared_ptr<TypedImage<uint16_t>>(
-               new TypedImage<uint16_t>(std::move(shape_), pixel_type_, plane_coordinate_, box_, index_m_));
+           ImagesContainerBase* bptr, size_t mem_index_, int index_m_) {
+           auto typedPtr = bptr->getBaseAsTyped<uint16_t>();
+           return std::shared_ptr<TypedImage<uint16_t>>( new TypedImage<uint16_t>(std::move(shape_), pixel_type_,
+                   plane_coordinate_, box_, typedPtr->getPointerAtIndex(mem_index_), index_m_
+                   ));
        }},
       {PixelType::Bgr48,
        [](std::vector<size_t> shape_, PixelType pixel_type_, const libCZI::CDimCoordinate* plane_coordinate_, libCZI::IntRect box_,
-           int index_m_) {
-           return std::shared_ptr<TypedImage<uint16_t>>(
-               new TypedImage<uint16_t>(std::move(shape_), pixel_type_, plane_coordinate_, box_, index_m_));
+           ImagesContainerBase* bptr, size_t mem_index_, int index_m_) {
+           auto typedPtr = bptr->getBaseAsTyped<uint16_t>();
+           return std::shared_ptr<TypedImage<uint16_t>>( new TypedImage<uint16_t>(std::move(shape_), pixel_type_,
+                   plane_coordinate_, box_, typedPtr->getPointerAtIndex(mem_index_), index_m_
+                   ));
        }},
       {PixelType::Gray32Float,
        [](std::vector<size_t> shape_, PixelType pixel_type_, const libCZI::CDimCoordinate* plane_coordinate_, libCZI::IntRect box_,
-           int index_m_) {
-           return std::shared_ptr<TypedImage<float>>(
-               new TypedImage<float>(std::move(shape_), pixel_type_, plane_coordinate_, box_, index_m_));
+           ImagesContainerBase* bptr, size_t mem_index_, int index_m_) {
+           auto typedPtr = bptr->getBaseAsTyped<float>();
+           return std::shared_ptr<TypedImage<float>>( new TypedImage<float>(std::move(shape_), pixel_type_,
+               plane_coordinate_, box_, typedPtr->getPointerAtIndex(mem_index_), index_m_
+               ));
        }},
       {PixelType::Bgr96Float,
        [](std::vector<size_t> shape_, PixelType pixel_type_, const libCZI::CDimCoordinate* plane_coordinate_, libCZI::IntRect box_,
-           int index_m_) {
-           return std::shared_ptr<TypedImage<float>>(
-               new TypedImage<float>(std::move(shape_), pixel_type_, plane_coordinate_, box_, index_m_));
+           ImagesContainerBase* bptr, size_t mem_index_, int index_m_) {
+           auto typedPtr = bptr->getBaseAsTyped<float>();
+           return std::shared_ptr<TypedImage<float>>( new TypedImage<float>(std::move(shape_), pixel_type_,
+               plane_coordinate_, box_, typedPtr->getPointerAtIndex(mem_index_), index_m_
+               ));
        }}
   };
 
@@ -46,17 +60,17 @@ namespace pylibczi {
       {PixelType::Bgr24,
        [](std::shared_ptr<Image> img_, int channel_) {
            return std::shared_ptr<TypedImage<uint8_t>>(
-               new TypedImage<uint8_t>(ImageFactory::getDerived< uint8_t >(img_), libCZI::PixelType::Gray8, channel_));
+               new TypedImage<uint8_t>(ImageFactory::getDerived<uint8_t>(img_), libCZI::PixelType::Gray8, channel_));
        }},
       {PixelType::Bgr48,
        [](std::shared_ptr<Image> img_, int channel_) {
            return std::shared_ptr<TypedImage<uint16_t>>(
-               new TypedImage<uint16_t>(ImageFactory::getDerived< uint16_t >(img_), libCZI::PixelType::Gray16, channel_));
+               new TypedImage<uint16_t>(ImageFactory::getDerived<uint16_t>(img_), libCZI::PixelType::Gray16, channel_));
        }},
       {PixelType::Bgr96Float,
        [](std::shared_ptr<Image> img_, int channel_) {
            return std::shared_ptr<TypedImage<float>>(
-               new TypedImage<float>(ImageFactory::getDerived< float >(img_), libCZI::PixelType::Gray32Float, channel_));
+               new TypedImage<float>(ImageFactory::getDerived<float>(img_), libCZI::PixelType::Gray32Float, channel_));
        }}
   };
 
@@ -116,7 +130,7 @@ namespace pylibczi {
   {
       Image::ImVec ivec;
       auto shape = img_in_->shape();
-      if (shape.size() != 3)
+      if (shape.size()!=3)
           throw ImageSplitChannelException("TypedImage  only has 2 dimensions. No channels to split.", 0);
       int cDim = 0;
 
@@ -125,12 +139,12 @@ namespace pylibczi {
       for (int i = 0; i<shape[0]; i++) {
           // TODO should I change the pixel type from a BGRx to a Grayx/3
           libCZI::PixelType pt = img_in_->pixelType();
-          if(pt == libCZI::PixelType::Invalid){
+          if (pt==libCZI::PixelType::Invalid) {
               img_in_->coordinatePtr()->TryGetPosition(libCZI::DimensionIndex::C, &cDim);
               throw ImageSplitChannelException("Only PixelTypes Bgr24, Bgr48, and Bgr96Float can be split! "
                                                "You have attempted to split an invalid PixelType", cDim);
           }
-          ivec.emplace_back(s_pixelToSplit[pt]( img_in_, i));
+          ivec.emplace_back(s_pixelToSplit[pt](img_in_, i));
       }
       return ivec;
   }

--- a/_aicspylibczi/ImageFactory.h
+++ b/_aicspylibczi/ImageFactory.h
@@ -38,6 +38,8 @@ namespace pylibczi {
 
       static size_t numberOfChannels(PixelType pixel_type_);
 
+      void setMosaic(bool val_) { m_imgContainer->images().setMosaic(val_); }
+
       template<typename T>
       static std::shared_ptr< TypedImage<T> >
       getDerived(std::shared_ptr<Image> image_ptr_)
@@ -51,6 +53,7 @@ namespace pylibczi {
       constructImage(const std::shared_ptr<libCZI::IBitmapData>& bitmap_ptr_, const libCZI::CDimCoordinate* plane_coordinate_,
           libCZI::IntRect box_, size_t mem_index_, int index_m_);
 
+      vector<std::pair<char, size_t>> getFixedShape(void);
   };
 }
 

--- a/_aicspylibczi/ImageFactory.h
+++ b/_aicspylibczi/ImageFactory.h
@@ -20,14 +20,19 @@ namespace pylibczi {
       using SplitCtorMap = std::map<libCZI::PixelType, std::function<std::shared_ptr<Image>( std::shared_ptr<Image> img_, int channel_) > >;
 
       static CtorMap s_pixelToImage;
-      static SplitCtorMap s_pixelToSplit;
 
       ImagesContainerBase::ImagesContainerBasePtr m_imgContainer;
 
   public:
-      ImageFactory::ImageFactory(libCZI::PixelType pixel_type_, size_t pixels_in_all_images_)
+      ImageFactory(libCZI::PixelType pixel_type_, size_t pixels_in_all_images_)
       : m_imgContainer(ImagesContainerBase::getTypedAsBase(pixel_type_, pixels_in_all_images_))
       {}
+
+      ImagesContainerBase::ImagesContainerBasePtr returnMemory(void){
+          return std::move(m_imgContainer); // this should empty m_imgContainer
+      }
+
+      size_t numberOfImages(void){ return m_imgContainer->numberOfImages(); }
 
       static size_t sizeOfPixelType(PixelType pixel_type_);
 
@@ -42,12 +47,9 @@ namespace pylibczi {
           return std::dynamic_pointer_cast<TypedImage<T>>(image_ptr_);
       }
 
-      static std::shared_ptr<Image>
+      std::shared_ptr<Image>
       constructImage(const std::shared_ptr<libCZI::IBitmapData>& bitmap_ptr_, const libCZI::CDimCoordinate* plane_coordinate_,
-          libCZI::IntRect box_,
-          int index_m_);
-
-      static Image::ImVec splitToChannels(std::shared_ptr<Image> img_in_);
+          libCZI::IntRect box_, size_t mem_index_, int index_m_);
 
   };
 }

--- a/_aicspylibczi/ImageFactory.h
+++ b/_aicspylibczi/ImageFactory.h
@@ -28,7 +28,7 @@ namespace pylibczi {
       : m_imgContainer(ImagesContainerBase::getTypedAsBase(pixel_type_, pixels_in_all_images_))
       {}
 
-      ImagesContainerBase::ImagesContainerBasePtr returnMemory(void){
+      ImagesContainerBase::ImagesContainerBasePtr transferMemoryContainer(void){
           return std::move(m_imgContainer); // this should empty m_imgContainer
       }
 

--- a/_aicspylibczi/ImageFactory.h
+++ b/_aicspylibczi/ImageFactory.h
@@ -17,7 +17,7 @@ namespace pylibczi {
                                    libCZI::IntRect box_, ImagesContainerBase* bptr,
                                    size_t img_index_, int mIndex_)
                                > >;
-      using SplitCtorMap = std::map<libCZI::PixelType, std::function<std::shared_ptr<Image>( std::shared_ptr<Image> img_, int channel_) > >;
+      using SplitCtorMap = std::map<libCZI::PixelType, std::function<std::shared_ptr<Image>(std::shared_ptr<Image> img_, int channel_)> >;
 
       static CtorMap s_pixelToImageConstructor;
 
@@ -25,14 +25,14 @@ namespace pylibczi {
 
   public:
       ImageFactory(libCZI::PixelType pixel_type_, size_t pixels_in_all_images_)
-      : m_imgContainer(ImagesContainerBase::getTypedAsBase(pixel_type_, pixels_in_all_images_))
-      {}
+          :m_imgContainer(ImagesContainerBase::getTypedAsBase(pixel_type_, pixels_in_all_images_)) { }
 
-      ImagesContainerBase::ImagesContainerBasePtr transferMemoryContainer(void){
+      ImagesContainerBase::ImagesContainerBasePtr transferMemoryContainer(void)
+      {
           return std::move(m_imgContainer); // this should empty m_imgContainer
       }
 
-      size_t numberOfImages(void){ return m_imgContainer->numberOfImages(); }
+      size_t numberOfImages(void) { return m_imgContainer->numberOfImages(); }
 
       static size_t sizeOfPixelType(PixelType pixel_type_);
 
@@ -41,7 +41,7 @@ namespace pylibczi {
       void setMosaic(bool val_) { m_imgContainer->images().setMosaic(val_); }
 
       template<typename T>
-      static std::shared_ptr< TypedImage<T> >
+      static std::shared_ptr<TypedImage<T> >
       getDerived(std::shared_ptr<Image> image_ptr_)
       {
           if (!image_ptr_->isTypeMatch<T>())

--- a/_aicspylibczi/ImageFactory.h
+++ b/_aicspylibczi/ImageFactory.h
@@ -19,7 +19,7 @@ namespace pylibczi {
                                > >;
       using SplitCtorMap = std::map<libCZI::PixelType, std::function<std::shared_ptr<Image>( std::shared_ptr<Image> img_, int channel_) > >;
 
-      static CtorMap s_pixelToImage;
+      static CtorMap s_pixelToImageConstructor;
 
       ImagesContainerBase::ImagesContainerBasePtr m_imgContainer;
 

--- a/_aicspylibczi/ImageFactory.h
+++ b/_aicspylibczi/ImageFactory.h
@@ -2,6 +2,7 @@
 #define _PYLIBCZI_IMAGEFACTORY_H
 
 #include "Image.h"
+#include "ImagesContainer.h"
 #include "TypedImage.h"
 #include "exceptions.h"
 
@@ -11,15 +12,23 @@ namespace pylibczi {
       using PixelType = libCZI::PixelType;
       using CtorMap = std::map<libCZI::PixelType,
                                std::function<std::shared_ptr<Image>(
-                                   std::vector<size_t>, libCZI::PixelType pixel_type_, const libCZI::CDimCoordinate* plane_coordinate_,
-                                   libCZI::IntRect box_, int mIndex_)
+                                   std::vector<size_t>, libCZI::PixelType pixel_type_,
+                                   const libCZI::CDimCoordinate* plane_coordinate_,
+                                   libCZI::IntRect box_, ImagesContainerBase* bptr,
+                                   size_t img_index_, int mIndex_)
                                > >;
       using SplitCtorMap = std::map<libCZI::PixelType, std::function<std::shared_ptr<Image>( std::shared_ptr<Image> img_, int channel_) > >;
 
       static CtorMap s_pixelToImage;
       static SplitCtorMap s_pixelToSplit;
 
+      ImagesContainerBase::ImagesContainerBasePtr m_imgContainer;
+
   public:
+      ImageFactory::ImageFactory(libCZI::PixelType pixel_type_, size_t pixels_in_all_images_)
+      : m_imgContainer(ImagesContainerBase::getTypedAsBase(pixel_type_, pixels_in_all_images_))
+      {}
+
       static size_t sizeOfPixelType(PixelType pixel_type_);
 
       static size_t numberOfChannels(PixelType pixel_type_);

--- a/_aicspylibczi/ImagesContainer.cpp
+++ b/_aicspylibczi/ImagesContainer.cpp
@@ -1,5 +1,0 @@
-//
-// Created by Jamie Sherman on 7/22/20.
-//
-
-#include "ImagesContainer.h"

--- a/_aicspylibczi/ImagesContainer.cpp
+++ b/_aicspylibczi/ImagesContainer.cpp
@@ -1,0 +1,5 @@
+//
+// Created by Jamie Sherman on 7/22/20.
+//
+
+#include "ImagesContainer.h"

--- a/_aicspylibczi/ImagesContainer.h
+++ b/_aicspylibczi/ImagesContainer.h
@@ -1,0 +1,12 @@
+//
+// Created by Jamie Sherman on 7/22/20.
+//
+
+#ifndef _AICSPYLIBCZI_IMAGESCONTAINER_H
+#define _AICSPYLIBCZI_IMAGESCONTAINER_H
+
+class ImagesContainer {
+
+};
+
+#endif //_AICSPYLIBCZI_IMAGESCONTAINER_H

--- a/_aicspylibczi/ImagesContainer.h
+++ b/_aicspylibczi/ImagesContainer.h
@@ -28,8 +28,8 @@ namespace pylibczi {
 
       template<typename T>
       ImagesContainer<T>* getBaseAsTyped(void)
-      {
-          return dynamic_cast< ImagesContainer<T>*>(this);
+      {   // this has to be static_cast because of the templating and the polymorphism 
+          return static_cast< ImagesContainer<T> *>(this);
       }
 
       void addImage( std::shared_ptr<Image> img_){ m_images.push_back(img_); }

--- a/_aicspylibczi/ImagesContainer.h
+++ b/_aicspylibczi/ImagesContainer.h
@@ -28,7 +28,7 @@ namespace pylibczi {
 
       template<typename T>
       ImagesContainer<T>* getBaseAsTyped(void)
-      {   // this has to be static_cast because of the templating and the polymorphism 
+      {   // this has to be static_cast because of the templating and the polymorphism
           return static_cast< ImagesContainer<T> *>(this);
       }
 

--- a/_aicspylibczi/ImagesContainer.h
+++ b/_aicspylibczi/ImagesContainer.h
@@ -5,8 +5,68 @@
 #ifndef _AICSPYLIBCZI_IMAGESCONTAINER_H
 #define _AICSPYLIBCZI_IMAGESCONTAINER_H
 
-class ImagesContainer {
+#include <memory>
 
-};
+#include "Image.h"
+#include "Reader.h"
 
+namespace pylibczi {
+
+  template<typename T> class ImagesContainer;
+
+  class ImagesContainerBase {
+  public:
+      using Shape = std::vector<std::pair<char, size_t> >;
+      using ImagesContainerBasePtr = std::unique_ptr<ImagesContainerBase>;
+
+      static ImagesContainerBasePtr getTypedAsBase(libCZI::PixelType& pixel_type_, size_t pixels_in_all_images_);
+
+      template<typename T>
+      ImagesContainer<T>* getBaseAsTyped(void)
+      {
+          return static_cast< ImagesContainer<T>*>(this);
+      }
+
+  private:
+      ImageVector m_images;
+      Shape m_shape;
+  };
+
+  template<typename T>
+  class ImagesContainer: public ImagesContainerBase {
+  private:
+      std::unique_ptr<T> m_uniquePtr;
+  public:
+      ImagesContainer(libCZI::PixelType pixel_type_, size_t pixels_in_all_images_)
+          :m_uniquePtr(new T[pixels_in_all_images_]) { }
+
+      T* getPointerAtIndex(size_t position_ = 0)
+      {
+          return m_uniquePtr.get()+position_;
+      }
+
+  };
+
+  ImagesContainerBase::ImagesContainerBasePtr
+  ImagesContainerBase::getTypedAsBase(libCZI::PixelType& pixel_type_, size_t pixels_in_all_images_)
+  {
+      ImagesContainerBasePtr imageMemory;
+      switch (pixel_type_) {
+      case libCZI::PixelType::Gray8:imageMemory = std::make_unique<ImagesContainer<uint8_t> >(pixel_type_, pixels_in_all_images_);
+          break;
+      case libCZI::PixelType::Gray16:imageMemory = std::make_unique<ImagesContainer<uint16_t> >(pixel_type_, pixels_in_all_images_);
+          break;
+      case libCZI::PixelType::Gray32Float:imageMemory = std::make_unique<ImagesContainer<float> >(pixel_type_, pixels_in_all_images_);
+          break;
+      case libCZI::PixelType::Bgr24:imageMemory = std::make_unique<ImagesContainer<uint8_t> >(pixel_type_, 3*pixels_in_all_images_);
+          break;
+      case libCZI::PixelType::Bgr48:imageMemory = std::make_unique<ImagesContainer<uint16_t> >(pixel_type_, 3*pixels_in_all_images_);
+          break;
+      case libCZI::PixelType::Bgr96Float:imageMemory = std::make_unique<ImagesContainer<float> >(pixel_type_, 3*pixels_in_all_images_);
+          break;
+      }
+      return imageMemory;
+  }
+
+}
 #endif //_AICSPYLIBCZI_IMAGESCONTAINER_H

--- a/_aicspylibczi/ImagesContainer.h
+++ b/_aicspylibczi/ImagesContainer.h
@@ -21,6 +21,7 @@ namespace pylibczi {
   private:
       ImageVector m_images;
       Shape m_shape;
+      libCZI::PixelType m_cziPixelType;
 
   public:
       static ImagesContainerBasePtr getTypedAsBase(libCZI::PixelType& pixel_type_, size_t pixels_in_all_images_);
@@ -41,6 +42,14 @@ namespace pylibczi {
               m_shape = m_images.getShape();
           return m_shape;
       }
+
+      void setCziFilePixelType(libCZI::PixelType pixel_type_){
+          m_cziPixelType = pixel_type_;
+      }
+
+      libCZI::PixelType pixelType(void){
+          return m_cziPixelType;
+      }
   };
 
   template<typename T>
@@ -56,6 +65,7 @@ namespace pylibczi {
           return m_uniquePtr.get()+position_;
       }
 
+      T* releaseMemory(void){ return m_uniquePtr.release(); }
   };
 
   inline
@@ -85,6 +95,7 @@ namespace pylibczi {
       case libCZI::PixelType::Invalid:
           throw PixelTypeException(pixel_type_, "unsupported pixel type.");
       }
+      imageMemory->setCziFilePixelType(pixel_type_); // make sure imageMemory has the original pixel type
       return imageMemory;
   }
 

--- a/_aicspylibczi/ImagesContainer.h
+++ b/_aicspylibczi/ImagesContainer.h
@@ -29,8 +29,10 @@ namespace pylibczi {
       template<typename T>
       ImagesContainer<T>* getBaseAsTyped(void)
       {   // this has to be static_cast because of the templating and the polymorphism
-          return static_cast< ImagesContainer<T> *>(this);
+          return dynamic_cast< ImagesContainer<T> *>(this);
       }
+
+      virtual ~ImagesContainerBase() {}
 
       void addImage( std::shared_ptr<Image> img_){ m_images.push_back(img_); }
 

--- a/_aicspylibczi/ImagesContainer.h
+++ b/_aicspylibczi/ImagesContainer.h
@@ -29,7 +29,7 @@ namespace pylibczi {
       template<typename T>
       ImagesContainer<T>* getBaseAsTyped(void)
       {
-          return static_cast< ImagesContainer<T>*>(this);
+          return dynamic_cast< ImagesContainer<T>*>(this);
       }
 
       void addImage( std::shared_ptr<Image> img_){ m_images.push_back(img_); }

--- a/_aicspylibczi/ImagesContainer.h
+++ b/_aicspylibczi/ImagesContainer.h
@@ -29,27 +29,30 @@ namespace pylibczi {
       template<typename T>
       ImagesContainer<T>* getBaseAsTyped(void)
       {   // this has to be static_cast because of the templating and the polymorphism
-          return dynamic_cast< ImagesContainer<T> *>(this);
+          return dynamic_cast< ImagesContainer<T>*>(this);
       }
 
-      virtual ~ImagesContainerBase() {}
+      virtual ~ImagesContainerBase() { }
 
-      void addImage( std::shared_ptr<Image> img_){ m_images.push_back(img_); }
+      void addImage(std::shared_ptr<Image> img_) { m_images.push_back(img_); }
 
-      size_t numberOfImages(void) {return m_images.size(); }
+      size_t numberOfImages(void) { return m_images.size(); }
 
-      ImageVector &images(void) { return m_images; }
-      Shape &shape(void) {
-          if(m_shape.empty() && m_images.size()!=0)
+      ImageVector& images(void) { return m_images; }
+      Shape& shape(void)
+      {
+          if (m_shape.empty() && m_images.size()!=0)
               m_shape = m_images.getShape();
           return m_shape;
       }
 
-      void setCziFilePixelType(libCZI::PixelType pixel_type_){
+      void setCziFilePixelType(libCZI::PixelType pixel_type_)
+      {
           m_cziPixelType = pixel_type_;
       }
 
-      libCZI::PixelType pixelType(void){
+      libCZI::PixelType pixelType(void)
+      {
           return m_cziPixelType;
       }
   };
@@ -67,7 +70,7 @@ namespace pylibczi {
           return m_uniquePtr.get()+position_;
       }
 
-      T* releaseMemory(void){ return m_uniquePtr.release(); }
+      T* releaseMemory(void) { return m_uniquePtr.release(); }
   };
 
   inline
@@ -84,18 +87,20 @@ namespace pylibczi {
           break;
       case libCZI::PixelType::Gray32Float:imageMemory = std::make_unique<ImagesContainer<float> >(pixel_type_, pixels_in_all_images_);
           break;
-      case libCZI::PixelType::Bgr24:imageMemory = std::make_unique<ImagesContainer<uint8_t> >(libCZI::PixelType::Gray8, 3*pixels_in_all_images_);
+      case libCZI::PixelType::Bgr24:
+          imageMemory = std::make_unique<ImagesContainer<uint8_t> >(libCZI::PixelType::Gray8, 3*pixels_in_all_images_);
           break;
-      case libCZI::PixelType::Bgr48:imageMemory = std::make_unique<ImagesContainer<uint16_t> >(libCZI::PixelType::Gray16, 3*pixels_in_all_images_);
+      case libCZI::PixelType::Bgr48:
+          imageMemory = std::make_unique<ImagesContainer<uint16_t> >(libCZI::PixelType::Gray16, 3*pixels_in_all_images_);
           break;
-      case libCZI::PixelType::Bgr96Float:imageMemory = std::make_unique<ImagesContainer<float> >(libCZI::PixelType::Gray32Float, 3*pixels_in_all_images_);
+      case libCZI::PixelType::Bgr96Float:
+          imageMemory = std::make_unique<ImagesContainer<float> >(libCZI::PixelType::Gray32Float, 3*pixels_in_all_images_);
           break;
       case libCZI::PixelType::Bgra32:
       case libCZI::PixelType::Gray64Float:
       case libCZI::PixelType::Gray64ComplexFloat:
       case libCZI::PixelType::Bgr192ComplexFloat:
-      case libCZI::PixelType::Invalid:
-          throw PixelTypeException(pixel_type_, "unsupported pixel type.");
+      case libCZI::PixelType::Invalid:throw PixelTypeException(pixel_type_, "unsupported pixel type.");
       }
       imageMemory->setCziFilePixelType(pixel_type_); // make sure imageMemory has the original pixel type
       return imageMemory;

--- a/_aicspylibczi/Reader.cpp
+++ b/_aicspylibczi/Reader.cpp
@@ -322,14 +322,9 @@ namespace pylibczi {
   Reader::getMatches(SubblockSortable& match_)
   {
       SubblockIndexVec ans;
-//      std::copy_if(m_orderMapping.begin(), m_orderMapping.end(), std::back_inserter(ans),
-//          [&match_](const SubblockIndexVec::value_type& a_) {
-//              return match_==a_.first;
-//          });
       m_czireader->EnumerateSubBlocks([&](int index_, const libCZI::SubBlockInfo& info_) -> bool {
           SubblockSortable subInfo(&(info_.coordinate), info_.mIndex, isMosaic(), info_.pixelType);
           if (isPyramid0(info_) && match_==subInfo) {
-              // std::cout << "match : " << *(match_.coordinatePtr()) << " adding: " << *(subInfo.coordinatePtr()) << std::endl;
               ans.emplace_back(std::pair<SubblockSortable, int>(subInfo, index_));
           }
           return true; // Enumerate through every subblock

--- a/_aicspylibczi/Reader.cpp
+++ b/_aicspylibczi/Reader.cpp
@@ -280,7 +280,7 @@ namespace pylibczi {
           throw pylibczi::CdimSelectionZeroImagesException(plane_coord_, m_statistics.dimBounds, "No pyramid0 selectable subblocks.");
       }
       auto charShape = imageFactory.getFixedShape();
-      return std::make_pair(imageFactory.returnMemory(), charShape);
+      return std::make_pair(imageFactory.transferMemoryContainer(), charShape);
   }
 
   SubblockMetaVec
@@ -411,7 +411,7 @@ namespace pylibczi {
       ImageFactory imageFactory(m_pixelType, pixels_in_image);
       auto image = imageFactory.constructImage(multiTileComposite, &plane_coord_, im_box_, 0, -1);
       // set is mosaic?
-      return imageFactory.returnMemory();
+      return imageFactory.transferMemoryContainer();
   }
 
 }

--- a/_aicspylibczi/Reader.cpp
+++ b/_aicspylibczi/Reader.cpp
@@ -404,7 +404,7 @@ namespace pylibczi {
 
       size_t pixels_in_image = m_statistics.boundingBoxLayer0Only.w*m_statistics.boundingBoxLayer0Only.h*bgrScaling;
       ImageFactory imageFactory(m_pixelType, pixels_in_image);
-      auto image = imageFactory.constructImage(multiTileComposite, &plane_coord_, im_box_, 0, -1);
+      imageFactory.constructImage(multiTileComposite, &plane_coord_, im_box_, 0, -1);
       // set is mosaic?
       return imageFactory.transferMemoryContainer();
   }

--- a/_aicspylibczi/Reader.cpp
+++ b/_aicspylibczi/Reader.cpp
@@ -244,7 +244,7 @@ namespace pylibczi {
       return ans;
   }
 
-  std::pair<ImagesContainerBase::ImagesContainerBasePtr, std::vector< std::pair<char, size_t> > >
+  std::pair<ImagesContainerBase::ImagesContainerBasePtr, std::vector<std::pair<char, size_t> > >
   Reader::readSelected(libCZI::CDimCoordinate& plane_coord_, int index_m_)
   {
       int pos;
@@ -270,7 +270,7 @@ namespace pylibczi {
               throw PixelTypeException(info.pixelType, "Selected subblocks have inconsistent PixelTypes."
                                                        " You must select subblocks with consistent PixelTypes.");
 
-          auto image = imageFactory.constructImage(subblock->CreateBitmap(),
+          imageFactory.constructImage(subblock->CreateBitmap(),
               &info.coordinate, info.logicalRect, memOffset, info.mIndex);
 
           memOffset += bgrScaling*w_by_h.w*w_by_h.h;
@@ -407,7 +407,7 @@ namespace pylibczi {
           scale_factor_,
           nullptr);   // use default options
 
-      size_t pixels_in_image = m_statistics.boundingBoxLayer0Only.w * m_statistics.boundingBoxLayer0Only.h * bgrScaling;
+      size_t pixels_in_image = m_statistics.boundingBoxLayer0Only.w*m_statistics.boundingBoxLayer0Only.h*bgrScaling;
       ImageFactory imageFactory(m_pixelType, pixels_in_image);
       auto image = imageFactory.constructImage(multiTileComposite, &plane_coord_, im_box_, 0, -1);
       // set is mosaic?

--- a/_aicspylibczi/Reader.cpp
+++ b/_aicspylibczi/Reader.cpp
@@ -244,7 +244,7 @@ namespace pylibczi {
       return ans;
   }
 
-  ImagesContainerBase::ImagesContainerBasePtr
+  std::pair<ImagesContainerBase::ImagesContainerBasePtr, std::vector< std::pair<char, size_t> > >
   Reader::readSelected(libCZI::CDimCoordinate& plane_coord_, int index_m_)
   {
       int pos;
@@ -260,6 +260,8 @@ namespace pylibczi {
       libCZI::IntRect w_by_h = getSceneYXSize();
       size_t n_of_pixels = matches.size()*w_by_h.w*w_by_h.h*bgrScaling;
       ImageFactory imageFactory(m_pixelType, n_of_pixels);
+
+      imageFactory.setMosaic(isMosaic());
       size_t memOffset = 0;
       for_each(matches.begin(), matches.end(), [&](const SubblockIndexVec::value_type& match_) {
           auto subblock = m_czireader->ReadSubBlock(match_.second);
@@ -277,7 +279,8 @@ namespace pylibczi {
       if (imageFactory.numberOfImages()==0) {
           throw pylibczi::CdimSelectionZeroImagesException(plane_coord_, m_statistics.dimBounds, "No pyramid0 selectable subblocks.");
       }
-      return imageFactory.returnMemory();
+      auto charShape = imageFactory.getFixedShape();
+      return std::make_pair(imageFactory.returnMemory(), charShape);
   }
 
   SubblockMetaVec

--- a/_aicspylibczi/Reader.h
+++ b/_aicspylibczi/Reader.h
@@ -93,7 +93,7 @@ namespace pylibczi {
       using DimIndexRangeMap = std::map<DimIndex, std::pair<int, int> >;
       using DimensionRangeMap = std::map<char, std::pair<int, int> >;
       using Shape = std::vector<std::pair<char, size_t> >;
-      using DimsShape = std::vector< DimIndexRangeMap >;
+      using DimsShape = std::vector<DimIndexRangeMap>;
 
       /*!
        * @brief Construct the Reader and load the file statistics (dimensions etc)
@@ -200,7 +200,7 @@ namespace pylibczi {
        * @param plane_coord_ A structure containing the Dimension constraints
        * @param index_m_ Is only relevant for mosaic files, if you wish to select one frame.
        */
-      std::pair<ImagesContainerBase::ImagesContainerBasePtr, std::vector< std::pair<char, size_t> > >
+      std::pair<ImagesContainerBase::ImagesContainerBasePtr, std::vector<std::pair<char, size_t> > >
       readSelected(libCZI::CDimCoordinate& plane_coord_, int index_m_ = -1);
 
       /*!
@@ -279,9 +279,10 @@ namespace pylibczi {
        */
       libCZI::IntRect getSceneYXSize(int scene_index_ = -1);
 
-      std::string pixelType() {
+      std::string pixelType()
+      {
           // each subblock can apparently have a different pixelType 🙄
-          if(m_pixelType == libCZI::PixelType::Invalid) m_pixelType = getFirstPixelType();
+          if (m_pixelType==libCZI::PixelType::Invalid) m_pixelType = getFirstPixelType();
           return libCZI::Utils::PixelTypeToInformalString(m_pixelType);
       }
 
@@ -294,7 +295,7 @@ namespace pylibczi {
           return (info_.logicalRect.w==info_.physicalSize.w && info_.logicalRect.h==info_.physicalSize.h);
       }
 
-      void getMemory(SubblockIndexVec & matches_);
+      void getMemory(SubblockIndexVec& matches_);
 
       static bool isValidRegion(const libCZI::IntRect& in_box_, const libCZI::IntRect& czi_box_);
 

--- a/_aicspylibczi/Reader.h
+++ b/_aicspylibczi/Reader.h
@@ -14,6 +14,7 @@
 #include "Image.h"
 #include "SubblockSortable.h"
 #include "SubblockMetaVec.h"
+#include "ImagesContainer.h"
 
 /*! \mainpage libCZI_c++_extension
  *
@@ -199,7 +200,7 @@ namespace pylibczi {
        * @param plane_coord_ A structure containing the Dimension constraints
        * @param index_m_ Is only relevant for mosaic files, if you wish to select one frame.
        */
-      std::pair<ImageVector, Shape> readSelected(libCZI::CDimCoordinate& plane_coord_, int index_m_ = -1);
+      ImagesContainerBase::ImagesContainerBasePtr readSelected(libCZI::CDimCoordinate& plane_coord_, int index_m_ = -1);
 
       /*!
        * @brief provide the subblock metadata in index order consistent with readSelected.
@@ -222,7 +223,7 @@ namespace pylibczi {
        * @param plane_coord_ A class constraining the data to an individual plane.
        * @param scale_factor_ (optional) The native size for mosaic files can be huge the scale factor allows one to get something back of a more reasonable size. The default is 0.1 meaning 10% of the native image.
        * @param im_box_ (optional) The {x0, y0, width, height} of a sub-region, the default is the whole image.
-       * @return an ImageVector of shared pointers containing an ImageBC*. See description of Image<> and ImageBC.
+       * @return an ImagesContainerBasePtr containing the raw memory, a list of images, and a list of corresponding dimensions
        *
        * @code
        *    FILE *fp = std::fopen("mosaicfile.czi", "rb");
@@ -238,7 +239,7 @@ namespace pylibczi {
        *    }
        * @endcode
        */
-      ImageVector
+      ImagesContainerBase::ImagesContainerBasePtr
       readMosaic(libCZI::CDimCoordinate plane_coord_, float scale_factor_ = 1.0, libCZI::IntRect im_box_ = {0, 0, -1, -1});
       // changed from {.w=-1, .h=-1} to above to support MSVC and GCC - lagging on C++14 std
 
@@ -296,6 +297,8 @@ namespace pylibczi {
       static bool isValidRegion(const libCZI::IntRect& in_box_, const libCZI::IntRect& czi_box_);
 
       void checkSceneShapes(void);
+
+      libCZI::PixelType getFirstPixelType(void);
   };
 
 }

--- a/_aicspylibczi/Reader.h
+++ b/_aicspylibczi/Reader.h
@@ -200,7 +200,8 @@ namespace pylibczi {
        * @param plane_coord_ A structure containing the Dimension constraints
        * @param index_m_ Is only relevant for mosaic files, if you wish to select one frame.
        */
-      ImagesContainerBase::ImagesContainerBasePtr readSelected(libCZI::CDimCoordinate& plane_coord_, int index_m_ = -1);
+      std::pair<ImagesContainerBase::ImagesContainerBasePtr, std::vector< std::pair<char, size_t> > >
+      readSelected(libCZI::CDimCoordinate& plane_coord_, int index_m_ = -1);
 
       /*!
        * @brief provide the subblock metadata in index order consistent with readSelected.
@@ -278,8 +279,9 @@ namespace pylibczi {
        */
       libCZI::IntRect getSceneYXSize(int scene_index_ = -1);
 
-      std::string pixelType() const {
+      std::string pixelType() {
           // each subblock can apparently have a different pixelType 🙄
+          if(m_pixelType == libCZI::PixelType::Invalid) m_pixelType = getFirstPixelType();
           return libCZI::Utils::PixelTypeToInformalString(m_pixelType);
       }
 

--- a/_aicspylibczi/Reader.h
+++ b/_aicspylibczi/Reader.h
@@ -286,12 +286,12 @@ namespace pylibczi {
 
       Reader::SubblockIndexVec getMatches(SubblockSortable& match_);
 
-      void addOrderMapping();
-
       static bool isPyramid0(const libCZI::SubBlockInfo& info_)
       {
           return (info_.logicalRect.w==info_.physicalSize.w && info_.logicalRect.h==info_.physicalSize.h);
       }
+
+      void getMemory(SubblockIndexVec & matches_);
 
       static bool isValidRegion(const libCZI::IntRect& in_box_, const libCZI::IntRect& czi_box_);
 

--- a/_aicspylibczi/SourceRange.h
+++ b/_aicspylibczi/SourceRange.h
@@ -25,19 +25,19 @@ namespace pylibczi {
            m_pixelsPerStride(pixels_per_stride_) { }
 
       class SourceChannelIterator {
-          std::vector<T*> m_ptrVector;
+          std::vector<T*> m_channelIterators;
 
       public:
           SourceChannelIterator(size_t number_of_channels_, T* ptr_)
-              :m_ptrVector(number_of_channels_)
+              :m_channelIterators(number_of_channels_)
           {
-              std::generate(m_ptrVector.begin(), m_ptrVector.end(), [ptr_]() mutable { return ptr_++; });
+              std::generate(m_channelIterators.begin(), m_channelIterators.end(), [ptr_]() mutable { return ptr_++; });
           }
 
           SourceChannelIterator& operator++()
           {
-              size_t numberOfChannels = m_ptrVector.size();
-              std::for_each(m_ptrVector.begin(), m_ptrVector.end(),
+              size_t numberOfChannels = m_channelIterators.size();
+              std::for_each(m_channelIterators.begin(), m_channelIterators.end(),
                   [numberOfChannels](T*& p_) { p_ = p_+numberOfChannels; });
               return *this;
           }
@@ -51,7 +51,7 @@ namespace pylibczi {
 
           bool operator==(const SourceChannelIterator& other_) const
           {
-              return *(m_ptrVector.begin())==*(other_.m_ptrVector.begin());
+              return *(m_channelIterators.begin())==*(other_.m_channelIterators.begin());
           }
 
           bool operator!=(const SourceChannelIterator& other_) const
@@ -61,7 +61,7 @@ namespace pylibczi {
 
           std::vector<T*>& operator*()
           {
-              return m_ptrVector;
+              return m_channelIterators;
           }
           // iterator traits
           using difference_type = size_t;

--- a/_aicspylibczi/SourceRange.h
+++ b/_aicspylibczi/SourceRange.h
@@ -59,7 +59,7 @@ namespace pylibczi {
               return !(*this==other_);
           }
 
-          std::vector<T*> operator*()
+          std::vector<T*> &operator*()
           {
               return m_ptr;
           }

--- a/_aicspylibczi/SourceRange.h
+++ b/_aicspylibczi/SourceRange.h
@@ -59,7 +59,7 @@ namespace pylibczi {
               return !(*this==other_);
           }
 
-          std::vector<T*> &operator*()
+          std::vector<T*>& operator*()
           {
               return m_ptrVector;
           }

--- a/_aicspylibczi/SourceRange.h
+++ b/_aicspylibczi/SourceRange.h
@@ -25,19 +25,19 @@ namespace pylibczi {
            m_pixelsPerStride(pixels_per_stride_) { }
 
       class SourceChannelIterator {
-          std::vector<T*> m_ptr;
+          std::vector<T*> m_ptrVector;
 
       public:
           SourceChannelIterator(size_t number_of_channels_, T* ptr_)
-              :m_ptr(number_of_channels_)
+              :m_ptrVector(number_of_channels_)
           {
-              std::generate(m_ptr.begin(), m_ptr.end(), [ptr_]() mutable { return ptr_++; });
+              std::generate(m_ptrVector.begin(), m_ptrVector.end(), [ptr_]() mutable { return ptr_++; });
           }
 
           SourceChannelIterator& operator++()
           {
-              size_t numberOfChannels = m_ptr.size();
-              std::for_each(m_ptr.begin(), m_ptr.end(),
+              size_t numberOfChannels = m_ptrVector.size();
+              std::for_each(m_ptrVector.begin(), m_ptrVector.end(),
                   [numberOfChannels](T*& p_) { p_ = p_+numberOfChannels; });
               return *this;
           }
@@ -51,7 +51,7 @@ namespace pylibczi {
 
           bool operator==(const SourceChannelIterator& other_) const
           {
-              return *(m_ptr.begin())==*(other_.m_ptr.begin());
+              return *(m_ptrVector.begin())==*(other_.m_ptrVector.begin());
           }
 
           bool operator!=(const SourceChannelIterator& other_) const
@@ -61,7 +61,7 @@ namespace pylibczi {
 
           std::vector<T*> &operator*()
           {
-              return m_ptr;
+              return m_ptrVector;
           }
           // iterator traits
           using difference_type = size_t;

--- a/_aicspylibczi/SubblockMetaVec.h
+++ b/_aicspylibczi/SubblockMetaVec.h
@@ -14,11 +14,12 @@
 
 namespace pylibczi {
 
-  class SubblockString : public SubblockSortable {
+  class SubblockString: public SubblockSortable {
       std::string m_string;
   public:
-      SubblockString(const libCZI::CDimCoordinate *plane_, int index_m_, bool is_mosaic_, char* str_p_, size_t str_size_)
-      :SubblockSortable(plane_, index_m_, is_mosaic_), m_string(str_p_, str_size_) {
+      SubblockString(const libCZI::CDimCoordinate* plane_, int index_m_, bool is_mosaic_, char* str_p_, size_t str_size_)
+          :SubblockSortable(plane_, index_m_, is_mosaic_), m_string(str_p_, str_size_)
+      {
           //clear string from garbage symbols
           std::regex lthan("&lt;"), gthan("&gt;"), spce("\\s*\\r\\n\\s*");
           std::regex metatag("</METADATA>.*"), quote("\\\"");
@@ -32,22 +33,25 @@ namespace pylibczi {
       std::string getString() const { return m_string; }
   };
 
-  class SubblockMetaVec: public std::vector< SubblockString > {
+  class SubblockMetaVec: public std::vector<SubblockString> {
       bool m_isMosaic = false;
   public:
-      SubblockMetaVec(): std::vector< SubblockString >() {}
+      SubblockMetaVec()
+          :std::vector<SubblockString>() { }
 
-      void setMosaic(bool mosaic_){ m_isMosaic = mosaic_; }
+      void setMosaic(bool mosaic_) { m_isMosaic = mosaic_; }
 
-      void sort(){
-          std::sort(begin(), end(), [](SubblockString& a_, SubblockString& b_)->bool{
-              return a_ < b_;
+      void sort()
+      {
+          std::sort(begin(), end(), [](SubblockString& a_, SubblockString& b_) -> bool {
+              return a_<b_;
           });
       }
 
       std::vector<std::pair<char, size_t> >
-      getShape(){
-          std::vector< std::map<char, size_t> > validIndexes;
+      getShape()
+      {
+          std::vector<std::map<char, size_t> > validIndexes;
           for (const auto& image : *this) {
               validIndexes.push_back(image.getValidIndexes(m_isMosaic)); // only add M if it's a mosaic file
           }
@@ -57,18 +61,18 @@ namespace pylibczi {
           std::vector<std::pair<char, size_t> > charSizes;
           std::map<char, std::set<size_t> > charSetSize;
           std::map<char, std::set<size_t> >::iterator found;
-          for( const auto& validMap : validIndexes){
-              for( auto keySet : validMap) {
+          for (const auto& validMap : validIndexes) {
+              for (auto keySet : validMap) {
                   found = charSetSize.emplace(keySet.first, std::set<size_t>()).first;
                   found->second.insert(keySet.second);
               }
           }
-          for( auto keySet : charSetSize){
+          for (auto keySet : charSetSize) {
               charSizes.emplace_back(keySet.first, keySet.second.size());
           }
           // sort them into descending DimensionIndex Order
-          std::sort(charSizes.begin(), charSizes.end(), [&](std::pair<char, size_t> a_, std::pair<char, size_t> b_){
-              return libCZI::Utils::CharToDimension(a_.first) > libCZI::Utils::CharToDimension(b_.first);
+          std::sort(charSizes.begin(), charSizes.end(), [&](std::pair<char, size_t> a_, std::pair<char, size_t> b_) {
+              return libCZI::Utils::CharToDimension(a_.first)>libCZI::Utils::CharToDimension(b_.first);
           });
           return charSizes;
       }

--- a/_aicspylibczi/SubblockSortable.h
+++ b/_aicspylibczi/SubblockSortable.h
@@ -7,18 +7,18 @@
 #include "inc_libCZI.h"
 #include "constants.h"
 
-namespace pylibczi{
+namespace pylibczi {
 
-  class SubblockSortable{
+  class SubblockSortable {
   protected:
-    libCZI::CDimCoordinate m_planeCoordinate;
-    libCZI::PixelType m_pixelType;
-    int m_indexM;
-    bool m_isMosaic;
+      libCZI::CDimCoordinate m_planeCoordinate;
+      libCZI::PixelType m_pixelType;
+      int m_indexM;
+      bool m_isMosaic;
   public:
-      SubblockSortable(const libCZI::CDimCoordinate  *plane_, int index_m_,bool is_mosaic_=false,
-          libCZI::PixelType pixel_type_=libCZI::PixelType::Invalid)
-      : m_planeCoordinate(plane_), m_pixelType(pixel_type_), m_indexM(index_m_), m_isMosaic(is_mosaic_) {}
+      SubblockSortable(const libCZI::CDimCoordinate* plane_, int index_m_, bool is_mosaic_ = false,
+          libCZI::PixelType pixel_type_ = libCZI::PixelType::Invalid)
+          :m_planeCoordinate(plane_), m_pixelType(pixel_type_), m_indexM(index_m_), m_isMosaic(is_mosaic_) { }
 
       const libCZI::CDimCoordinate* coordinatePtr() const { return &m_planeCoordinate; }
 
@@ -26,11 +26,12 @@ namespace pylibczi{
 
       libCZI::PixelType pixelType(void) const { return m_pixelType; }
 
-      std::map<char, size_t>  getDimsAsChars() const {
+      std::map<char, size_t> getDimsAsChars() const
+      {
           return SubblockSortable::getValidIndexes(m_planeCoordinate, m_indexM, m_isMosaic);
       }
 
-      static std::map<char, size_t> getValidIndexes(const libCZI::CDimCoordinate& planecoord_, int index_m_, bool is_mosaic_=false)
+      static std::map<char, size_t> getValidIndexes(const libCZI::CDimCoordinate& planecoord_, int index_m_, bool is_mosaic_ = false)
       {
           std::map<char, size_t> ans;
           for (auto di : Constants::s_sortOrder) {
@@ -41,32 +42,37 @@ namespace pylibczi{
           return ans;
       }
 
-      std::map<char, size_t> getValidIndexes(bool is_mosaic_ = false) const {
+      std::map<char, size_t> getValidIndexes(bool is_mosaic_ = false) const
+      {
           return SubblockSortable::getValidIndexes(m_planeCoordinate, m_indexM, is_mosaic_);
       }
 
-      bool operator<(const SubblockSortable& other_) const {
-          if(!m_isMosaic || m_indexM == -1 || other_.m_indexM == -1)
+      bool operator<(const SubblockSortable& other_) const
+      {
+          if (!m_isMosaic || m_indexM==-1 || other_.m_indexM==-1)
               return SubblockSortable::aLessThanB(m_planeCoordinate, other_.m_planeCoordinate);
           return SubblockSortable::aLessThanB(m_planeCoordinate, m_indexM, other_.m_planeCoordinate, other_.m_indexM);
       }
 
-      bool operator==(const SubblockSortable &other_) const {
-          return !(*this < other_) && !(other_ < *this);
+      bool operator==(const SubblockSortable& other_) const
+      {
+          return !(*this<other_) && !(other_<*this);
       }
 
-      static bool aLessThanB(const libCZI::CDimCoordinate &a_, const libCZI::CDimCoordinate &b_){
-          for(auto di : Constants::s_sortOrder){
+      static bool aLessThanB(const libCZI::CDimCoordinate& a_, const libCZI::CDimCoordinate& b_)
+      {
+          for (auto di : Constants::s_sortOrder) {
               int aValue, bValue;
-              if(a_.TryGetPosition(di, &aValue) && b_.TryGetPosition(di, &bValue) &&  aValue != bValue)
-                  return aValue < bValue;
+              if (a_.TryGetPosition(di, &aValue) && b_.TryGetPosition(di, &bValue) && aValue!=bValue)
+                  return aValue<bValue;
           }
           return false;
       }
 
-      static bool aLessThanB(const libCZI::CDimCoordinate &a_, const int a_index_m_, const libCZI::CDimCoordinate &b_, const int b_index_m_){
-          if( !aLessThanB(a_, b_) && !aLessThanB(b_, a_) )
-              return a_index_m_ < b_index_m_;
+      static bool aLessThanB(const libCZI::CDimCoordinate& a_, const int a_index_m_, const libCZI::CDimCoordinate& b_, const int b_index_m_)
+      {
+          if (!aLessThanB(a_, b_) && !aLessThanB(b_, a_))
+              return a_index_m_<b_index_m_;
           return aLessThanB(a_, b_);
       }
   };

--- a/_aicspylibczi/SubblockSortable.h
+++ b/_aicspylibczi/SubblockSortable.h
@@ -20,6 +20,8 @@ namespace pylibczi {
           libCZI::PixelType pixel_type_ = libCZI::PixelType::Invalid)
           :m_planeCoordinate(plane_), m_pixelType(pixel_type_), m_indexM(index_m_), m_isMosaic(is_mosaic_) { }
 
+      virtual ~SubblockSortable() { }
+
       const libCZI::CDimCoordinate* coordinatePtr() const { return &m_planeCoordinate; }
 
       int mIndex() const { return m_indexM; }

--- a/_aicspylibczi/SubblockSortable.h
+++ b/_aicspylibczi/SubblockSortable.h
@@ -12,15 +12,19 @@ namespace pylibczi{
   class SubblockSortable{
   protected:
     libCZI::CDimCoordinate m_planeCoordinate;
+    libCZI::PixelType m_pixelType;
     int m_indexM;
     bool m_isMosaic;
   public:
-      SubblockSortable(const libCZI::CDimCoordinate  *plane_, int index_m_, bool is_mosaic_=false)
-      : m_planeCoordinate(plane_), m_indexM(index_m_), m_isMosaic(is_mosaic_) {}
+      SubblockSortable(const libCZI::CDimCoordinate  *plane_, int index_m_,bool is_mosaic_=false,
+          libCZI::PixelType pixel_type_=libCZI::PixelType::Invalid)
+      : m_planeCoordinate(plane_), m_pixelType(pixel_type_), m_indexM(index_m_), m_isMosaic(is_mosaic_) {}
 
       const libCZI::CDimCoordinate* coordinatePtr() const { return &m_planeCoordinate; }
 
       int mIndex() const { return m_indexM; }
+
+      libCZI::PixelType pixelType(void) const { return m_pixelType; }
 
       std::map<char, size_t>  getDimsAsChars() const {
           return SubblockSortable::getValidIndexes(m_planeCoordinate, m_indexM, m_isMosaic);

--- a/_aicspylibczi/TargetRange.h
+++ b/_aicspylibczi/TargetRange.h
@@ -64,7 +64,7 @@ namespace pylibczi {
               return !(*this==other_);
           }
 
-          std::vector<T*> operator*()
+          std::vector<T*> &operator*()
           {
               return m_ptr;
           }

--- a/_aicspylibczi/TargetRange.h
+++ b/_aicspylibczi/TargetRange.h
@@ -64,7 +64,7 @@ namespace pylibczi {
               return !(*this==other_);
           }
 
-          std::vector<T*> &operator*()
+          std::vector<T*>& operator*()
           {
               return m_ptr;
           }

--- a/_aicspylibczi/TypedImage.h
+++ b/_aicspylibczi/TypedImage.h
@@ -26,7 +26,7 @@ namespace pylibczi {
        * @param m_index_ The mosaic index for the image, this is only relevant if the file is a mosaic file.
        */
       TypedImage(std::vector<size_t> shape_, libCZI::PixelType pixel_type_, const libCZI::CDimCoordinate* plane_coordantes_,
-          libCZI::IntRect box_, T *mem_ptr_, int m_index_)
+          libCZI::IntRect box_, T* mem_ptr_, int m_index_)
           :Image(shape_, pixel_type_, plane_coordantes_, box_, m_index_),
            m_array(mem_ptr_)
       {
@@ -120,11 +120,12 @@ namespace pylibczi {
   // TODO: right thing to do but I'll likely have to come back and fix some of this.
   template<typename T>
   inline std::pair<T*, T*>
-  TypedImage<T>::channelPtrs(int channel_){
+  TypedImage<T>::channelPtrs(int channel_)
+  {
       std::pair<T*, T*> ans;
-      size_t planeSize = std::accumulate(m_shape.rbegin(), --(m_shape.rend()), 1, std::multiplies<size_t>() );
-      ans.first = m_array + channel_ * planeSize;
-      ans.second = ans.first + planeSize;
+      size_t planeSize = std::accumulate(m_shape.rbegin(), --(m_shape.rend()), 1, std::multiplies<size_t>());
+      ans.first = m_array+channel_*planeSize;
+      ans.second = ans.first+planeSize;
       return ans;
   }
 

--- a/_aicspylibczi/TypedImage.h
+++ b/_aicspylibczi/TypedImage.h
@@ -35,20 +35,6 @@ namespace pylibczi {
       }
 
       /*!
-       * @brief This constructor is strictly for splitting out a {H, W} Image from a {3, H, W} Image
-       * @param img_ a std::shared_ptr<Image> with shape {3, H, W}
-       * @param channel_ which of the 3 channels {0, 1, or 2} to copy out of Image
-       */
-      TypedImage( std::shared_ptr< TypedImage > img_, libCZI::PixelType pt_, int channel_):
-            TypedImage({img_->shape()[1], img_->shape()[2]}, pt_, img_->coordinatePtr(), img_->bBox(), img_->mIndex())
-      {
-          m_planeCoordinate.Set(libCZI::DimensionIndex::B, 0);  // to be consistent with other types
-          m_planeCoordinate.Set(libCZI::DimensionIndex::C, channel_);
-          auto ptrPair = img_->channelPtrs(channel_); // BGR24 has type uint8_t so the ptr's should be of the right type
-          std::copy( ptrPair.first, ptrPair.second, m_array );
-      }
-
-      /*!
        * @brief the [] accessor, for accessing or changing a pixel value
        * @param idxs_xy_ The X, Y coordinate in the plane (or X, Y, C} order if 3D. can be provided as an initializer list {x, y, c}
        * @return a reference to the pixel

--- a/_aicspylibczi/TypedImage.h
+++ b/_aicspylibczi/TypedImage.h
@@ -53,7 +53,7 @@ namespace pylibczi {
        * @param jump_to_ an integer offset from the beginning of the array.
        * @return a pointer to the internally managed memory. Image maintains ownership!
        */
-      T* getRawPtr(int jump_to_ = 0) { return m_array+jump_to_; }
+      T* getRawPtr(size_t jump_to_ = 0) { return m_array+jump_to_; }
 
       /*!
        * return a pointer to the specified memory poisiton

--- a/_aicspylibczi/TypedImage.h
+++ b/_aicspylibczi/TypedImage.h
@@ -12,7 +12,7 @@ namespace pylibczi {
 
   template<typename T>
   class TypedImage: public Image {
-      std::unique_ptr<T[]> m_array;
+      T* m_array; // raw pointer to memory in ImagesContainer
 
   public:
       /*!
@@ -22,12 +22,13 @@ namespace pylibczi {
        * @param pixel_type_ The Pixel type of the image,
        * @param plane_coordantes_ The coordinate structure used to define the plane, what scene, channel, time-point etc.
        * @param box_ The (x0, y0, w, h) structure containing the logical position of the image.
+       * @param mem_ptr_ The raw pointer to the position to write the image into.
        * @param m_index_ The mosaic index for the image, this is only relevant if the file is a mosaic file.
        */
       TypedImage(std::vector<size_t> shape_, libCZI::PixelType pixel_type_, const libCZI::CDimCoordinate* plane_coordantes_,
-          libCZI::IntRect box_, int m_index_)
+          libCZI::IntRect box_, T *mem_ptr_, int m_index_)
           :Image(shape_, pixel_type_, plane_coordantes_, box_, m_index_),
-           m_array(new T[std::accumulate(shape_.begin(), shape_.end(), (size_t) 1, std::multiplies<>())])
+           m_array(mem_ptr_)
       {
           if (!isTypeMatch<T>())
               throw PixelTypeException(m_pixelType, "TypedImage asked to create a container for PixelType with inconsitent type.");
@@ -44,7 +45,7 @@ namespace pylibczi {
           m_planeCoordinate.Set(libCZI::DimensionIndex::B, 0);  // to be consistent with other types
           m_planeCoordinate.Set(libCZI::DimensionIndex::C, channel_);
           auto ptrPair = img_->channelPtrs(channel_); // BGR24 has type uint8_t so the ptr's should be of the right type
-          std::copy( ptrPair.first, ptrPair.second, m_array.get() );
+          std::copy( ptrPair.first, ptrPair.second, m_array );
       }
 
       /*!
@@ -66,7 +67,7 @@ namespace pylibczi {
        * @param jump_to_ an integer offset from the beginning of the array.
        * @return a pointer to the internally managed memory. Image maintains ownership!
        */
-      T* getRawPtr(int jump_to_ = 0) { return m_array.get()+jump_to_; }
+      T* getRawPtr(int jump_to_ = 0) { return m_array+jump_to_; }
 
       /*!
        * return a pointer to the specified memory poisiton
@@ -74,18 +75,6 @@ namespace pylibczi {
        * @return A pointer into the raw internal data (Image still maintains ownership of the memory).
        */
       T* getRawPtr(std::vector<size_t> list_); // inline definititon below
-
-      /*!
-       * @brief This function releases the memory from the container and gives it to the recipient to handle. The recipient takes
-       * responsible for freeing the memory.
-       * @return The raw pointer of type T*, where T is the storage type corresponding with the PixelType
-       */
-      T* releaseMemory()
-      {
-          if (!isTypeMatch<T>())
-              throw PixelTypeException(pixelType(), "TypedImage PixelType is inconsistent with requested memory type.");
-          return m_array.release();
-      }
 
       /*!
        * @brief Copy the image from the libCZI bitmap object into this Image object
@@ -129,7 +118,7 @@ namespace pylibczi {
           // WARNING do not compute the end of the array by multiplying stride by height, they are both uint32_t and you'll get an overflow for larger images
           uint8_t* sEnd = static_cast<uint8_t*>(lckScoped.ptrDataRoi)+lckScoped.size;
           SourceRange<T> sourceRange(channels_, static_cast<T*>(lckScoped.ptrDataRoi), (T*) (sEnd), lckScoped.stride, size.w);
-          TargetRange<T> targetRange(channels_, size.w, size.h, m_array.get(), m_array.get()+length());
+          TargetRange<T> targetRange(channels_, size.w, size.h, m_array, m_array+length());
           for (std::uint32_t h = 0; h<bitmap_ptr_->GetHeight(); ++h) {
               pairedForEach(sourceRange.strideBegin(h), sourceRange.strideEnd(h), targetRange.strideBegin(h),
                   [&](std::vector<T*> src_, std::vector<T*> tgt_) {
@@ -141,12 +130,14 @@ namespace pylibczi {
       }
   }
 
+  // TODO: I need to think about how I'm handling BGR images and the memory. I think splitting them off the bat is the
+  // TODO: right thing to do but I'll likely have to come back and fix some of this.
   template<typename T>
   inline std::pair<T*, T*>
   TypedImage<T>::channelPtrs(int channel_){
       std::pair<T*, T*> ans;
       size_t planeSize = std::accumulate(m_shape.rbegin(), --(m_shape.rend()), 1, std::multiplies<size_t>() );
-      ans.first = m_array.get() + channel_ * planeSize;
+      ans.first = m_array + channel_ * planeSize;
       ans.second = ans.first + planeSize;
       return ans;
   }

--- a/_aicspylibczi/constants.cpp
+++ b/_aicspylibczi/constants.cpp
@@ -4,17 +4,16 @@
 namespace pylibczi {
 
   const std::initializer_list<Constants::CziDi>
-  Constants::s_sortOrder{Constants::CziDi::B,
-                         Constants::CziDi::V,
-                         Constants::CziDi::H,
-                         Constants::CziDi::I,
-                         Constants::CziDi::S,
-                         Constants::CziDi::R,
-                         Constants::CziDi::T,
-                         Constants::CziDi::C,
-                         Constants::CziDi::Z
+      Constants::s_sortOrder{Constants::CziDi::B,
+                             Constants::CziDi::V,
+                             Constants::CziDi::H,
+                             Constants::CziDi::I,
+                             Constants::CziDi::S,
+                             Constants::CziDi::R,
+                             Constants::CziDi::T,
+                             Constants::CziDi::C,
+                             Constants::CziDi::Z
   };
-
 
   bool
   Constants::dimsMatch(const libCZI::CDimCoordinate& target_dims_, const libCZI::CDimCoordinate& czi_dims_)

--- a/_aicspylibczi/constants.h
+++ b/_aicspylibczi/constants.h
@@ -8,7 +8,7 @@
 
 #include "inc_libCZI.h"
 
-namespace pylibczi{
+namespace pylibczi {
 
   struct Constants {
       using CziDi = libCZI::DimensionIndex;

--- a/_aicspylibczi/exceptions.h
+++ b/_aicspylibczi/exceptions.h
@@ -83,7 +83,7 @@ namespace pylibczi {
   class ImageIteratorException: public std::exception {
       std::string m_message;
   public:
-      explicit ImageIteratorException(const std::string &message_)
+      explicit ImageIteratorException(const std::string& message_)
           :m_message("ImageIteratorException: "+message_) { }
 
       const char* what() const noexcept override
@@ -96,7 +96,7 @@ namespace pylibczi {
       std::string m_message;
       int m_channel;
   public:
-      ImageSplitChannelException(const std::string &message_, int channel_)
+      ImageSplitChannelException(const std::string& message_, int channel_)
           :m_message("ImageSplitChannelExcetion: "+message_), m_channel(channel_) { }
 
       const char* what() const noexcept override
@@ -129,13 +129,14 @@ namespace pylibczi {
   class CDimCoordinatesOverspecifiedException: public std::exception {
       std::string m_message;
   public:
-      explicit CDimCoordinatesOverspecifiedException(std::string message_): m_message(std::move(message_)) {}
+      explicit CDimCoordinatesOverspecifiedException(std::string message_)
+          :m_message(std::move(message_)) { }
 
       const char* what() const noexcept override
       {
           std::stringstream tmp;
           tmp << "The coordinates are overspecified = you have specified a Dimension or Dimension value that is not valid. "
-          << m_message << std::endl;
+              << m_message << std::endl;
           return tmp.str().c_str();
       }
   };
@@ -143,7 +144,8 @@ namespace pylibczi {
   class CDimCoordinatesUnderspecifiedException: public std::exception {
       std::string m_message;
   public:
-      explicit CDimCoordinatesUnderspecifiedException(std::string message_): m_message(std::move(message_)) {}
+      explicit CDimCoordinatesUnderspecifiedException(std::string message_)
+          :m_message(std::move(message_)) { }
 
       const char* what() const noexcept override
       {

--- a/_aicspylibczi/pb_bindings.cpp
+++ b/_aicspylibczi/pb_bindings.cpp
@@ -9,7 +9,7 @@
 // the below headers are crucial otherwise the custom casts aren't recognized
 #include "pb_caster_BytesIO.h"
 #include "pb_caster_DimIndex.h"
-#include "pb_caster_ImageVector.h"
+#include "pb_caster_ImagesContainer.h"
 #include "pb_caster_SubblockMetaVec.h"
 #include "pb_caster_libCZI_DimensionIndex.h"
 

--- a/_aicspylibczi/pb_caster_BytesIO.h
+++ b/_aicspylibczi/pb_caster_BytesIO.h
@@ -6,10 +6,9 @@
 #include <iostream>
 #include "CSimpleStreamImplFromFd.h"
 
-
 namespace pybind11 {
   namespace detail {
-    template<> struct type_caster< std::shared_ptr<libCZI::IStream> > {
+    template<> struct type_caster<std::shared_ptr<libCZI::IStream> > {
     public:
         /**
          * This macro establishes the name 'FILE *' in

--- a/_aicspylibczi/pb_caster_ImagesContainer.h
+++ b/_aicspylibczi/pb_caster_ImagesContainer.h
@@ -1,21 +1,21 @@
-#ifndef _PYLIBCZI_PB_CASTER_IMAGEVECTOR_H
-#define _PYLIBCZI_PB_CASTER_IMAGEVECTOR_H
+#ifndef _PYLIBCZI_PB_CASTER_IMAGESCONTAINER_H
+#define _PYLIBCZI_PB_CASTER_IMAGESCONTAINER_H
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
-#include "Image.h"
+#include "ImagesContainer.h"
 #include "pb_helpers.h"
 
 namespace pybind11 {
   namespace detail {
-    template<> struct type_caster<pylibczi::ImageVector> {
+    template<> struct type_caster<pylibczi::ImagesContainerBase::ImagesContainerBasePtr> {
     public:
         /**
          * This macro establishes the name pylibczi::ImageVector  in
          * function signatures and declares a local variable
          * 'value' of type pylibczi::ImageVector
          */
-    PYBIND11_TYPE_CASTER(pylibczi::ImageVector, _("numpy.ndarray"));
+    PYBIND11_TYPE_CASTER(pylibczi::ImagesContainerBase::ImagesContainerBasePtr, _("numpy.ndarray"));
 
         /**
          * Conversion part 1 (Python->C++): convert a PyObject( numpy.ndarray ) into an ImageVector
@@ -24,7 +24,7 @@ namespace pybind11 {
          */
         bool load(handle src_, bool)
         {
-            // Currently not used, if casting a numpy.ndarray to an ImageVector is required this must be implemented=
+            // Currently not used, if casting a numpy.ndarray to an ImagesContainer is required this must be implemented=
 
             /* Extract PyObject from handle */
             PyObject* source = src_.ptr();
@@ -32,13 +32,13 @@ namespace pybind11 {
         }
 
         /**
-         * Conversion part 2 (C++ -> Python): convert a pylibCZI::ImageVector instance into
+         * Conversion part 2 (C++ -> Python): convert a pylibCZI::ImagesContainer instance into
          * a Python object, specifically a numpy.ndarray. The second and third arguments are used to
          * indicate the return value policy and parent object (for
          * ``return_value_policy::reference_internal``) and are generally
          * ignored by implicit casters.
          */
-        static handle cast(pylibczi::ImageVector src_, return_value_policy /* policy */, handle /* parent */)
+        static handle cast(pylibczi::ImagesContainerBase::ImagesContainerBasePtr src_, return_value_policy /* policy */, handle /* parent */)
         {
             return pb_helpers::packArray(src_);
         }

--- a/_aicspylibczi/pb_caster_ImagesContainer.h
+++ b/_aicspylibczi/pb_caster_ImagesContainer.h
@@ -11,14 +11,14 @@ namespace pybind11 {
     template<> struct type_caster<pylibczi::ImagesContainerBase::ImagesContainerBasePtr> {
     public:
         /**
-         * This macro establishes the name pylibczi::ImageVector  in
+         * This macro establishes the name pylibczi::ImageContainerBasePtr in
          * function signatures and declares a local variable
-         * 'value' of type pylibczi::ImageVector
+         * 'value' of type pylibczi::ImageContainerBasePtr
          */
     PYBIND11_TYPE_CASTER(pylibczi::ImagesContainerBase::ImagesContainerBasePtr, _("numpy.ndarray"));
 
         /**
-         * Conversion part 1 (Python->C++): convert a PyObject( numpy.ndarray ) into an ImageVector
+         * Conversion part 1 (Python->C++): convert a PyObject( numpy.ndarray ) into an ImageContainerBasePtr
          * instance or return false upon failure. The second argument
          * indicates whether implicit conversions should be applied.
          */
@@ -40,7 +40,7 @@ namespace pybind11 {
          */
         static handle cast(pylibczi::ImagesContainerBase::ImagesContainerBasePtr src_, return_value_policy /* policy */, handle /* parent */)
         {
-            return pb_helpers::packArray(src_);
+            return pb_helpers::packArray(src_);  // the helper takes the ImagesContainerBasePtr and converts it to a numpy ndarray
         }
     };
   }

--- a/_aicspylibczi/pb_helpers.h
+++ b/_aicspylibczi/pb_helpers.h
@@ -17,36 +17,27 @@
 namespace py=pybind11;
 namespace pb_helpers {
 
-  py::array packArray(pylibczi::ImageVector& images_);
+  py::array packArray(pylibczi::ImagesContainerBase::ImagesContainerBasePtr &base_ptr_);
   py::list *packStringArray(pylibczi::SubblockMetaVec& metadata_);
+  std::vector<std::pair<char, size_t> > getAndFixShape(pylibczi::ImagesContainerBase *bptr_);
 
-  template<typename T>
-  py::array* makeArray(size_t size_, std::vector<ssize_t>& shape_, pylibczi::ImageVector& images_)
-  {
-      if (size_==0) return new py::array_t<T>({1}, new T);
-      T* ptr;
-      try {
-          ptr = new T[size_];
-      }
-      catch (std::bad_alloc& ba) {
-          std::cout << ba.what() << std::endl;
-          throw pylibczi::ImageCopyAllocFailed("try using a more constraints (S=1, T=5, etc on the DimensionIndex).", size_);
-      }
+  template <typename T>
+  py::array *memoryToNpArray(pylibczi::ImagesContainerBase *bptr_, std::vector<std::pair<char, size_t> > &charSizes_){
+      pylibczi::ImagesContainer<T>* tptr = bptr_->getBaseAsTyped<T>();
 
-      T* position = ptr;
-      for (const auto& image : images_) {
-          auto typedImage = pylibczi::ImageFactory::getDerived<T>(image);
-          size_t length = typedImage->length();
-          std::copy(typedImage->getRawPtr(), typedImage->getRawPtr()+length, position);
-          position += length;
-      }
+      std::vector<ssize_t> shape(charSizes_.size(), 0);
+      std::transform(charSizes_.begin(), charSizes_.end(), shape.begin(), [](const std::pair<char, size_t>& a_) {
+          return a_.second;
+      });
 
-      py::capsule freeWhenDone(ptr, [](void* f_) {
+      T* mptr = tptr->releaseMemory();
+
+      py::capsule freeWhenDone(mptr, [](void* f_) {
           T* ptr = reinterpret_cast<T*>(f_);
           delete[] ptr;
       });
 
-      return new py::array_t<T>(shape_, ptr, freeWhenDone);
+      return new py::array_t<T>(shape, mptr, freeWhenDone);
   }
 
 }

--- a/aicspylibczi/tests/test_czi_file.py
+++ b/aicspylibczi/tests/test_czi_file.py
@@ -139,7 +139,7 @@ def test_mosaic_size(data_dir, fname, expected):
     ('s_1_t_1_c_1_z_1.czi', (1, 1, 325, 475)),  # B C Y X
     ('s_3_t_1_c_3_z_5.czi', (1, 3, 3, 5, 325, 475)),  # B S C Z Y X
     ('mosaic_test.czi', (1, 1, 1, 1, 2, 624, 924)),  # S T C Z M Y X
-    ('RGB-8bit.czi', (1, 1, 3, 624, 924)),  # B T C Y X
+    ('RGB-8bit.czi', (1, 3, 624, 924)),  # T C Y X
 ])
 def test_read_image(data_dir, fname, expected):
     czi = CziFile(str(data_dir / fname))
@@ -249,7 +249,7 @@ def test_mosaic_image(data_dir, fname, expects):
 
 
 @pytest.mark.parametrize("fname, expects", [
-    ('mosaic_test.czi', (1, 1, int(624/2), int(1756/2))),
+    ('mosaic_test.czi', (1, int(624/2), int(1756/2))),
 ])
 def test_mosaic_image_two(data_dir, fname, expects):
     with open(data_dir / fname, 'rb') as fp:

--- a/c_tests/test_Image.cpp
+++ b/c_tests/test_Image.cpp
@@ -40,7 +40,7 @@ public:
         auto cDims = libCZI::CDimCoordinate{{libCZI::DimensionIndex::B, 0},
                                             {libCZI::DimensionIndex::C, 0}};
         auto imgCont = m_czi->readSelected(cDims);
-        auto imVec = imgCont->images();
+        auto imVec = imgCont.first->images();
         return imVec.front();
     }
 };

--- a/c_tests/test_Image.cpp
+++ b/c_tests/test_Image.cpp
@@ -39,7 +39,8 @@ public:
     {
         auto cDims = libCZI::CDimCoordinate{{libCZI::DimensionIndex::B, 0},
                                             {libCZI::DimensionIndex::C, 0}};
-        auto imVec = m_czi->readSelected(cDims).first;
+        auto imgCont = m_czi->readSelected(cDims);
+        auto imVec = imgCont->images();
         return imVec.front();
     }
 };
@@ -67,7 +68,8 @@ TEST_CASE_METHOD(CziImageCreator, "test_image_nothrow", "[Image_Cast_Nothrow]")
 TEST_CASE("test_image_accessors", "[Image_operator[]]")
 {
     libCZI::CDimCoordinate cdim{{libCZI::DimensionIndex::S, 1}, {libCZI::DimensionIndex::C, 1}};
-    TypedImage<uint16_t> img({3, 4, 5}, libCZI::PixelType::Gray16, &cdim, {0, 0, 5, 4}, -1);
+    auto uMemPtr = std::unique_ptr<uint16_t>( new uint16_t[60] );
+    TypedImage<uint16_t> img({3, 4, 5}, libCZI::PixelType::Gray16, &cdim, {0, 0, 5, 4}, uMemPtr.get(), -1);
     uint16_t ip[60];
     for (int i = 0; i<3*4*5; i++) ip[i] = i/3+1;
 
@@ -104,7 +106,8 @@ TEST_CASE("test_image_accessors", "[Image_operator[]]")
 TEST_CASE("test_image_accessors_2d", "[Image_operator[2d]]")
 {
     libCZI::CDimCoordinate cdim{{libCZI::DimensionIndex::S, 1}, {libCZI::DimensionIndex::C, 1}};
-    TypedImage<uint16_t> img({4, 5}, libCZI::PixelType::Gray16, &cdim, {0, 0, 5, 4}, -1);
+    auto uMemPtr = std::unique_ptr<uint16_t>( new uint16_t[20] );
+    TypedImage<uint16_t> img({4, 5}, libCZI::PixelType::Gray16, &cdim, {0, 0, 5, 4}, uMemPtr.get(), -1);
     uint16_t ip[20];
     for (int i = 0; i<4*5; i++) ip[i] = i+1;
 

--- a/c_tests/test_Reader.cpp
+++ b/c_tests/test_Reader.cpp
@@ -37,6 +37,8 @@ public:
     pylibczi::Reader* get() { return m_czi.get(); }
 };
 
+#ifdef LOCAL_TEST
+
 class CziCreatorBig {
     std::unique_ptr<pylibczi::Reader> m_czi;
 public:
@@ -44,6 +46,8 @@ public:
         :m_czi(new pylibczi::Reader(L"/Users/jamies/Data/20190425_S08_001-04-Scene-4-P3-B03.czi")) { }
     pylibczi::Reader* get() { return m_czi.get(); }
 };
+
+#endif
 
 class CziCreator4 {
     std::unique_ptr<pylibczi::Reader> m_czi;
@@ -465,6 +469,8 @@ TEST_CASE_METHOD(CziBgrCreator2, "test_bgr_7channel", "[Reader_bgr_7channel]")
     REQUIRE( shape==shapeAns);
 }
 
+#ifdef LOCAL_TEST
+
 TEST_CASE_METHOD(CziCreatorBig, "test_big_czifile", "[Reader_timed_read]")
 {
     auto czi = get();
@@ -492,3 +498,5 @@ TEST_CASE_METHOD(CziCreatorBig, "test_big_czifile", "[Reader_timed_read]")
     std::cout << "Duration(milliseconds): " << std::chrono::duration_cast<std::chrono::milliseconds>(done-start).count();
     REQUIRE(std::chrono::duration_cast<std::chrono::milliseconds>(done-start).count()<5050);
 }
+
+#endif

--- a/c_tests/test_Reader.cpp
+++ b/c_tests/test_Reader.cpp
@@ -1,5 +1,7 @@
+#include <chrono>
 #include <cstdio>
 #include <algorithm>
+#include <sstream>
 
 #include "catch.hpp"
 
@@ -35,6 +37,22 @@ public:
     pylibczi::Reader* get() { return m_czi.get(); }
 };
 
+class CziCreatorBig {
+    std::unique_ptr<pylibczi::Reader> m_czi;
+public:
+    CziCreatorBig()
+        :m_czi(new pylibczi::Reader(L"/Users/jamies/Data/20190425_S08_001-04-Scene-4-P3-B03.czi")) { }
+    pylibczi::Reader* get() { return m_czi.get(); }
+};
+
+class CziCreator4 {
+    std::unique_ptr<pylibczi::Reader> m_czi;
+public:
+    CziCreator4()
+        :m_czi(new pylibczi::Reader(L"/Users/jamies/Data/s_1_t_10_c_3_z_1.czi")) { }
+    pylibczi::Reader* get() { return m_czi.get(); }
+};
+
 TEST_CASE_METHOD(CziCreatorIStream, "test_reader_constructor", "[Reader]")
 {
     REQUIRE_NOTHROW(get());
@@ -55,8 +73,8 @@ TEST_CASE_METHOD(CziCreator, "test_reader_dims_1", "[Reader_Dims]")
     auto czi = get();
     auto dimsVec = czi->readDimsRange();
     REQUIRE(czi->shapeIsConsistent());
-    REQUIRE(dimsVec.size() == 1);
-    REQUIRE(dimsVec == ans);
+    REQUIRE(dimsVec.size()==1);
+    REQUIRE(dimsVec==ans);
 }
 
 /* The file for this test is too large to commit to the repo
@@ -104,7 +122,7 @@ TEST_CASE_METHOD(CziCreator2, "test_reader_dims_3", "[Reader_Dims_Size]")
     std::vector<int> shape = {1, 3, 3, 5, 325, 475};
     REQUIRE(czi->shapeIsConsistent());
     REQUIRE(dstr=="BSCZYX");
-    REQUIRE(dims == shape);
+    REQUIRE(dims==shape);
 }
 
 TEST_CASE_METHOD(CziCreator, "test_is_mosaic", "[Reader_Is_Mosaic]")
@@ -211,14 +229,14 @@ TEST_CASE_METHOD(CziMCreator, "test_mosaic_is_mosaic", "[Reader_mosaic_is_mosaic
 TEST_CASE_METHOD(CziMCreator, "test_mosaic_dims", "[Reader_mosaic_dims]")
 {
     auto czi = get();
-    REQUIRE(czi->dimsString() == std::string("STCZMYX"));
+    REQUIRE(czi->dimsString()==std::string("STCZMYX"));
 }
 
 TEST_CASE_METHOD(CziMCreator, "test_mosaic_dimsSize", "[Reader_mosaic_dimsSize]")
 {
     auto czi = get();
     std::vector<int> ans{1, 1, 1, 1, 2, 624, 924};
-    REQUIRE(czi->dimSizes() == ans);
+    REQUIRE(czi->dimSizes()==ans);
 }
 
 TEST_CASE_METHOD(CziMCreator, "test_mosaic_readdims", "[Reader_mosaic_readdims]")
@@ -229,11 +247,11 @@ TEST_CASE_METHOD(CziMCreator, "test_mosaic_readdims", "[Reader_mosaic_readdims]"
         {
             {DI::S, {0, 1}}, {DI::T, {0, 1}}, {DI::C, {0, 1}},
             {DI::Z, {0, 1}}, {DI::M, {0, 2}},
-            {DI::Y, {0, 624}}, {DI::X, {0, 924} }
+            {DI::Y, {0, 624}}, {DI::X, {0, 924}}
         }
     };
     auto val = czi->readDimsRange();
-    REQUIRE(val == ans);
+    REQUIRE(val==ans);
 }
 
 TEST_CASE_METHOD(CziMCreator, "test_mosaic_readSelected", "[Reader_mosaic_readSelected]")
@@ -296,7 +314,7 @@ TEST_CASE_METHOD(CziBgrCreator, "test_bgr_read", "[Reader_read_bgr]")
     REQUIRE(dims==ansDims);
 
     REQUIRE(pr.first.size()==3);
-    REQUIRE(pr.first.front()->shape() == std::vector<size_t>{624, 924});
+    REQUIRE(pr.first.front()->shape()==std::vector<size_t>{624, 924});
     REQUIRE(pr.first.front()->pixelType()==libCZI::PixelType::Gray8);
 }
 
@@ -325,16 +343,16 @@ TEST_CASE_METHOD(CziMCreator, "test_reader_mosaic_subblockinforect", "[Reader_Mo
 {
     auto czi = get();
 
-    std::vector< libCZI::IntRect > answers{{0, 0, 924, 624}, {832, 0, 924, 624}};
+    std::vector<libCZI::IntRect> answers{{0, 0, 924, 624}, {832, 0, 924, 624}};
 
     libCZI::CDimCoordinate dm;
-    for( int m_index = 0; m_index < 2 ; m_index++) {
+    for (int m_index = 0; m_index<2; m_index++) {
         auto rect = czi->readSubblockRect(dm, m_index);
         auto answer = answers[m_index];
-        REQUIRE( rect.x == answer.x);
-        REQUIRE( rect.y == answer.y);
-        REQUIRE( rect.w == answer.w);
-        REQUIRE( rect.h == answer.h);
+        REQUIRE(rect.x==answer.x);
+        REQUIRE(rect.y==answer.y);
+        REQUIRE(rect.w==answer.w);
+        REQUIRE(rect.h==answer.h);
     }
     int invalid_m = 2;
     REQUIRE_THROWS_AS(czi->readSubblockRect(dm, invalid_m), pylibczi::CDimCoordinatesOverspecifiedException);
@@ -391,11 +409,11 @@ TEST_CASE_METHOD(CziBgrCreator2, "test_bgr2_read", "[Reader_read_bgr2]")
     REQUIRE(dims==ansDims);
 
     REQUIRE(pr.first.size()==3);
-    REQUIRE(pr.first.front()->shape() == std::vector<size_t>{81, 147});
+    REQUIRE(pr.first.front()->shape()==std::vector<size_t>{81, 147});
     REQUIRE(pr.first.front()->pixelType()==libCZI::PixelType::Gray8);
-    auto c_pair = std::find_if(pr.second.begin(), pr.second.end(), [](const std::pair< char, int> &a){ return a.first == 'C'; });
-    REQUIRE(c_pair->first == 'C');
-    REQUIRE(c_pair->second == 3);
+    auto c_pair = std::find_if(pr.second.begin(), pr.second.end(), [](const std::pair<char, int>& a) { return a.first=='C'; });
+    REQUIRE(c_pair->first=='C');
+    REQUIRE(c_pair->second==3);
 }
 
 TEST_CASE_METHOD(CziBgrCreator2, "test_bgr2_flatten", "[Reader_read_flatten_bgr2]")
@@ -424,4 +442,32 @@ TEST_CASE_METHOD(CziBgrCreator2, "test_bgr_exception", "[Reader_flatten_bgr_exce
     libCZI::CDimCoordinate dm;
     REQUIRE_THROWS_AS(czi->readSelected(dm, -1), pylibczi::ImageAccessUnderspecifiedException);
 
+}
+
+TEST_CASE_METHOD(CziCreatorBig, "test_big_czifile", "[Reader_timed_read]")
+{
+    auto czi = get();
+    libCZI::CDimCoordinate dm = libCZI::CDimCoordinate{{libCZI::DimensionIndex::B, 0},
+                                                       {libCZI::DimensionIndex::S, 0},
+                                                       {libCZI::DimensionIndex::T, 1},
+                                                       {libCZI::DimensionIndex::Z, 5}};
+
+    std::stringstream info("Dims: ");
+    info << czi->dimsString();
+    INFO(info.str());
+    auto dSizes = czi->dimSizes();
+
+    std::stringstream dsizes("Shape: {");
+    for_each(dSizes.begin(), dSizes.end(), [&dsizes](const int& x) {
+        dsizes << x << ", ";
+    });
+    dsizes << "}" << std::endl;
+    INFO( dsizes.str() );
+
+    auto start = std::chrono::high_resolution_clock::now();
+    auto pr = czi->readSelected(dm);
+    auto done = std::chrono::high_resolution_clock::now();
+
+    std::cout << "Duration(milliseconds): " << std::chrono::duration_cast<std::chrono::milliseconds>(done-start).count();
+    REQUIRE(std::chrono::duration_cast<std::chrono::milliseconds>(done-start).count()<5000);
 }

--- a/c_tests/test_Reader.cpp
+++ b/c_tests/test_Reader.cpp
@@ -150,7 +150,7 @@ TEST_CASE_METHOD(CziCreator, "test_read_selected", "[Reader_read_selected]")
 //                                        {{libCZI::DimensionIndex::B, 0},
 //                                        {libCZI::DimensionIndex::C, 0}};
     auto imCont = czi->readSelected(cDims);
-    auto imvec = imCont->images();
+    auto imvec = imCont.first->images();
     REQUIRE(imvec.size()==1);
     auto shape = imvec.front()->shape();
     REQUIRE(shape[0]==325); // height
@@ -163,7 +163,7 @@ TEST_CASE_METHOD(CziCreator2, "test_read_selected2", "[Reader_read_selected]")
     auto cDims = libCZI::CDimCoordinate{{libCZI::DimensionIndex::B, 0},
                                         {libCZI::DimensionIndex::C, 0}};
     auto imCont = czi->readSelected(cDims);
-    auto imvec = imCont->images();
+    auto imvec = imCont.first->images();
     REQUIRE(imvec.size()==15);
     auto shape = imvec.front()->shape();
     REQUIRE(shape[0]==325); // height
@@ -175,7 +175,7 @@ TEST_CASE_METHOD(CziCreatorIStream, "test_read_selected3", "[Reader_read_selecte
     auto czi = get();
     auto cDims = libCZI::CDimCoordinate{{libCZI::DimensionIndex::C, 0}};
     auto imCont = czi->readSelected(cDims);
-    auto imvec = imCont->images();
+    auto imvec = imCont.first->images();
     REQUIRE(imvec.size()==1);
     auto shape = imvec.front()->shape();
     REQUIRE(shape[0]==325); // height
@@ -187,7 +187,7 @@ TEST_CASE_METHOD(CziCreatorIStream, "test_read_selected4", "[Reader_read_selecte
     auto czi = get();
     auto cDims = libCZI::CDimCoordinate();
     auto imCont = czi->readSelected(cDims);
-    auto imvec = imCont->images();
+    auto imvec = imCont.first->images();
     REQUIRE(imvec.size()==1);
     auto shape = imvec.front()->shape();
     REQUIRE(shape[0]==325); // height
@@ -267,7 +267,7 @@ TEST_CASE_METHOD(CziMCreator, "test_mosaic_readSelected", "[Reader_mosaic_readSe
     REQUIRE(sze==szeAns);
     libCZI::CDimCoordinate c_dims;
     auto imCont = czi->readSelected(c_dims);
-    auto imvec = imCont->images();
+    auto imvec = imCont.first->images();
     REQUIRE(imvec.size()==2);
 }
 
@@ -308,7 +308,7 @@ TEST_CASE_METHOD(CziBgrCreator, "test_bgr_read", "[Reader_read_bgr]")
     auto czi = get();
     libCZI::CDimCoordinate dm;
     auto imgCont = czi->readSelected(dm);
-    auto pr = imgCont->images();
+    auto pr = imgCont.first->images();
 
     REQUIRE(czi->dimsString()==std::string("TYX"));
     std::vector<int> ansSize{1, 624, 924};
@@ -333,8 +333,8 @@ TEST_CASE_METHOD(CziBgrCreator, "test_bgr_flatten", "[Reader_read_flatten_bgr]")
 
     libCZI::CDimCoordinate dm;
     auto imgCont = czi->readSelected(dm, -1);
-    auto pr = imgCont->images();
-    auto shape = imgCont->shape();
+    auto pr = imgCont.first->images();
+    auto shape = imgCont.second;
     REQUIRE(pr.size()==1);
 
     for (auto x : pr) {
@@ -343,7 +343,7 @@ TEST_CASE_METHOD(CziBgrCreator, "test_bgr_flatten", "[Reader_read_flatten_bgr]")
         REQUIRE(x->shape()[2]==924);
     }
 
-    pylibczi::Reader::Shape shapeAns{{'T', 1}, {'Y', 624}, {'X', 924}};
+    pylibczi::Reader::Shape shapeAns{{'T', 1}, {'C', 3}, {'Y', 624}, {'X', 924}};
 
     REQUIRE(shape==shapeAns);
     REQUIRE(pr.front()->pixelType()==libCZI::PixelType::Gray8);
@@ -408,8 +408,8 @@ TEST_CASE_METHOD(CziBgrCreator2, "test_bgr2_read", "[Reader_read_bgr2]")
     libCZI::CDimCoordinate dm = libCZI::CDimCoordinate{{libCZI::DimensionIndex::B, 0},
                                                        {libCZI::DimensionIndex::C, 4}};
     auto imgCont = czi->readSelected(dm);
-    auto pr = imgCont->images();
-    auto shape = imgCont->shape();
+    auto pr = imgCont.first->images();
+    auto shape = imgCont.second;
 
     REQUIRE(czi->dimsString()==std::string("SCYX"));
     std::vector<int> ansSize{1, 7, 81, 147};
@@ -437,8 +437,8 @@ TEST_CASE_METHOD(CziBgrCreator2, "test_bgr2_flatten", "[Reader_read_flatten_bgr2
     auto dims = czi->readDimsRange();
     libCZI::CDimCoordinate dm = libCZI::CDimCoordinate{{libCZI::DimensionIndex::C, 4}};
     auto imgCont = czi->readSelected(dm, -1);
-    auto pr = imgCont->images();
-    auto shape = imgCont->shape();
+    auto pr = imgCont.first->images();
+    auto shape = imgCont.second;
 
     REQUIRE(pr.size()==1);
 
@@ -448,7 +448,7 @@ TEST_CASE_METHOD(CziBgrCreator2, "test_bgr2_flatten", "[Reader_read_flatten_bgr2
         REQUIRE(x->shape()[2]==147);
     }
 
-    pylibczi::Reader::Shape shapeAns{{'S', 1}, {'C', 1}, {'Y', 81}, {'X', 147}};
+    pylibczi::Reader::Shape shapeAns{{'S', 1}, {'C', 3}, {'Y', 81}, {'X', 147}};
     REQUIRE(shape==shapeAns);
     REQUIRE(pr.front()->pixelType()==libCZI::PixelType::Gray8);
     // pb_helpers::packArray(pr.first);
@@ -459,9 +459,9 @@ TEST_CASE_METHOD(CziBgrCreator2, "test_bgr_7channel", "[Reader_bgr_7channel]")
     auto czi = get();
     libCZI::CDimCoordinate dm;
     auto imCont = czi->readSelected(dm, -1);
-    auto images = imCont->images();
-    auto shape = imCont->shape();
-    pylibczi::Reader::Shape shapeAns{{'S', 1}, {'C', 7}, {'Y', 81}, {'X', 147}};
+    auto images = imCont.first->images();
+    auto shape = imCont.second;
+    pylibczi::Reader::Shape shapeAns{{'S', 1}, {'C', 21}, {'Y', 81}, {'X', 147}};
     REQUIRE( shape==shapeAns);
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -4,12 +4,25 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <locale>
+#include <codecvt>
+#include <string>
 
 #include "_aicspylibczi/Reader.h"
 
 int
-main(void){
-    pylibczi::Reader czi(L"/Users/jamies/Data/s_1_t_10_c_3_z_1.czi");
+main(int argc, char *argv[]){
+    if(argc != 2){
+        std::cout << "This executable is intended for profiling. It requires the user provide the path to a large czi file." << std::endl;\
+        std::cout << "Example Usage: profile_me /Users/jamies/Data/s_1_t_10_c_3_z_1.czi" << std::endl;
+        std::cerr << "Program called with insufficient or excess arguments!" << std::endl;
+        exit(0);
+    }
+
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+    std::wstring wide = converter.from_bytes(argv[1]);
+
+    pylibczi::Reader czi( wide.c_str() ); // L"/Users/jamies/Data/s_1_t_10_c_3_z_1.czi");
 
     libCZI::CDimCoordinate dm = libCZI::CDimCoordinate{{libCZI::DimensionIndex::B, 0},
                                                        {libCZI::DimensionIndex::S, 0}};

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,34 @@
+//
+// This is a test program fro profiling performance
+//
+
+#include <cstdio>
+#include <cstdlib>
+
+#include "_aicspylibczi/Reader.h"
+
+int
+main(void){
+    pylibczi::Reader czi(L"/Users/jamies/Data/s_1_t_10_c_3_z_1.czi");
+
+    libCZI::CDimCoordinate dm = libCZI::CDimCoordinate{{libCZI::DimensionIndex::B, 0},
+                                                       {libCZI::DimensionIndex::S, 0}};
+
+    std::cout << "Dims: " << czi.dimsString() << std::endl;
+    auto dSizes = czi.dimSizes();
+
+    std::cout << "Shape: {" ;
+    for_each(dSizes.begin(), dSizes.end(), [](const int &x){
+        std::cout << x << ", ";
+    });
+    std::cout << "}" << std::endl;
+
+    auto start = std::chrono::high_resolution_clock::now();
+    auto pr = czi.readSelected(dm);
+    auto done = std::chrono::high_resolution_clock::now();
+
+
+    std::cout << "Duration(milliseconds): " << std::chrono::duration_cast<std::chrono::milliseconds>(done-start).count();
+
+    return 0;
+}


### PR DESCRIPTION
The goal of this branch was to change how memory for the numpy array was handled more efficiently. 

The memory container is the ImagesContainer class that returns the typed memory via polymorphism. 
Pointers from the single block of memory are used to construct TypedImages with references to where their image should be written. The TypedImage then copies the bitmap to the memory TypedImage is pointing to.

The code changes rely on polymorphism to handle the different types of memory. This is a lot more complicated than casting a void * and maybe a little nutty but I find it a bit scary to have exposed code that requires the memory to be casted to the right type. This approach means all the logic is self-contained in the relevant classes. I'd love your thoughts on this design style.

If you have suggestions on commenting, coding style, design or any other points I'd really appreciate it. 
 