### PR TITLE
Update/submodule uri

### DIFF
--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -5,11 +5,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
         with:
-          ref: update/submodule_uri
           submodules: true
-          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
@@ -23,7 +21,7 @@ jobs:
         with:
           python-versions: 'cp37-cp37m'
           build-requirements: 'cython numpy make cmake==3.17.3'
-          pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
+          pre-build-command: 'cmake --version'
       - name: List Files
         run: |
           ls dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -19,9 +19,8 @@ jobs:
       - name: Build manylinux Python wheels
         uses: allen-cell-animated/python-wheels-manylinux-build@v1.1
         with:
-          python-versions: 'cp37-cp37m'
+          python-versions: 'cp37-cp37m cp38-cp38m'
           build-requirements: 'cython numpy make cmake==3.17.3 twine wheel'
-          pre-build-command: '/bin/bash scripts/docker_setup.sh'
-      - name: List Files
+      - name: Upload Files
         run: |
-          ls dist/*-manylinux*.whl
+          ls dist/*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -17,9 +17,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install twine
       - name: Build manylinux Python wheels
-        uses: RalfG/python-wheels-manylinux-build@v0.3.1-pypywheels/manylinux2010-pypy_x86_64:latest
+        uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
         with:
           python-versions: 'cp37-cp37m'
+          system-packages: 'gcc.x86_64'
           build-requirements: 'cython numpy make cmake==3.17.3'
           pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
       - name: List Files

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-versions: 'cp37-cp37m'
           build-requirements: 'cython numpy make cmake==3.17.3'
-          pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
+          pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:/opt/rh/devtoolset-8/root/usr/bin:$PATH'
       - name: List Files
         run: |
           dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -19,8 +19,9 @@ jobs:
       - name: Build manylinux Python wheels
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
         with:
+          system-packages: 'cmake'
           python-versions: 'cp37-cp37m'
-          build-requirements: 'cython numpy cmake==3.14.3'
+          build-requirements: 'cython numpy'
           pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
       - name: List Files
         run: |

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -17,7 +17,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install twine
       - name: Build manylinux Python wheels
-        uses: allen-cell-animated/python-wheels-manylinux-build@v1
+        uses: allen-cell-animated/python-wheels-manylinux-build@v1.1
         with:
           python-versions: 'cp37-cp37m'
           build-requirements: 'cython numpy make cmake==3.17.3 twine wheel'

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -5,7 +5,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        fetch-depth: 0
         with:
           submodules: true
       - name: Set up Python

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -17,7 +17,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install twine
       - name: Build manylinux Python wheels
-        uses: RalfG/python-wheels-manylinux-build@v0.3.1-pypywheels/manylinux2010-pypy_x86_64
+        uses: RalfG/python-wheels-manylinux-build@v0.3.1
         with:
           python-versions: 'cp37-cp37m'
           build-requirements: 'cython numpy make cmake==3.17.3'

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -17,7 +17,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install twine
       - name: Build manylinux Python wheels
-        uses: RalfG/python-wheels-manylinux-build@v0.3.1-pypywheels/manylinux2010-pypy_x86_64
+        uses: RalfG/python-wheels-manylinux-build@v0.3.1-pypywheels\/manylinux2010-pypy_x86_64
         with:
           python-versions: 'cp37-cp37m'
           build-requirements: 'cython numpy make cmake==3.17.3'

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -20,7 +20,7 @@ jobs:
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
         with:
           python-versions: 'cp37-cp37m'
-          system-packages: 'gcc.x86_64 gcc-g++'
+          system-packages: 'gcc-c++'
           build-requirements: 'cython numpy make cmake==3.17.3'
           pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
       - name: List Files

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           python-versions: 'cp37-cp37m'
           build-requirements: 'cython numpy make cmake==3.17.3 twine wheel'
+          pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
       - name: List Files
         run: |
           ls dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -16,6 +16,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install twine
+          pip install cmake==3.13.3
       - name: Build manylinux Python wheels
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
         with:

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -21,7 +21,8 @@ jobs:
         with:
           python-versions: 'cp37-cp37m'
           build-requirements: 'cython numpy make cmake==3.17.3 twine wheel'
-          pre-build-command: 'bash script/docker_setup.sh'
+          package-path: 'aicspylibczi'
+          pre-build-command: 'bash aicspylibczi/script/docker_setup.sh'
       - name: List Files
         run: |
           ls dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -21,7 +21,7 @@ jobs:
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
         with:
           python-versions: 'cp36-cp36m cp37-cp37m'
-          build-requirements: 'cython numpy'
+          build-requirements: 'cython numpy cmake==3.14.3'
       - name: List Files
         run: |
           dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build manylinux Python wheels
         uses: allen-cell-animated/python-wheels-manylinux-build@v1.1
         with:
-          python-versions: 'cp37-cp37m cp38-cp38m'
+          python-versions: 'cp37-cp37m cp38-cp38'
           build-requirements: 'cython numpy make cmake==3.17.3 twine wheel'
       - name: Upload Files
         run: |

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-versions: 'cp37-cp37m'
           build-requirements: 'cython numpy make cmake==3.17.3 twine wheel'
-          pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
+          pre-build-command: '/opt/python/cp37-cp37m/bin/python scripts/docker_setup.sh'
       - name: List Files
         run: |
           ls dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-versions: 'cp37-cp37m'
           build-requirements: 'cython numpy cmake=3.14.3'
-          pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
+          pre-build-command: 'which cmake; cmake --version'
       - name: List Files
         run: |
           dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -19,9 +19,8 @@ jobs:
       - name: Build manylinux Python wheels
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
         with:
-          system-packages: 'cmake'
           python-versions: 'cp37-cp37m'
-          build-requirements: 'cython numpy'
+          build-requirements: 'cython numpy cmake=3.14.3'
           pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
       - name: List Files
         run: |

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -17,12 +17,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install twine
       - name: Build manylinux Python wheels
-        uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
+        uses: RalfG/python-wheels-manylinux-build@v0.3.1-pypywheels/manylinux2010-pypy_x86_64
         with:
           python-versions: 'cp37-cp37m'
           system-packages: 'gcc-c++'
           build-requirements: 'cython numpy make cmake==3.17.3'
           pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH; which g++'
+        run: |
+          echo "${{ steps.tagName.outputs.tag }}"
       - name: List Files
         run: |
           dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -7,6 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          ref: update/submodule_uri
           submodules: true
           fetch-depth: 0
       - name: Set up Python

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -17,7 +17,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install twine
       - name: Build manylinux Python wheels
-        uses: RalfG/python-wheels-manylinux-build@v0.3.1-pypywheels\/manylinux2010-pypy_x86_64
+        uses: RalfG/python-wheels-manylinux-build@v0.3.1-pypywheels/manylinux2010-pypy_x86_64:latest
         with:
           python-versions: 'cp37-cp37m'
           build-requirements: 'cython numpy make cmake==3.17.3'

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-versions: 'cp37-cp37m'
           build-requirements: 'cython numpy make cmake==3.17.3 twine wheel'
-          pre-build-command: '/opt/python/cp37-cp37m/bin/python scripts/docker_setup.sh'
+          pre-build-command: '/bin/bash scripts/docker_setup.sh'
       - name: List Files
         run: |
           ls dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -17,7 +17,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install twine
       - name: Build manylinux Python wheels
-        uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010-pypy_x86_64
+        uses: RalfG/python-wheels-manylinux-build@v0.3.1-pypywheels/manylinux2010-pypy_x86_64
         with:
           python-versions: 'cp37-cp37m'
           build-requirements: 'cython numpy make cmake==3.17.3'

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -1,5 +1,8 @@
 name: Python package build and publish
-on: push
+on:
+  push:
+    branches:
+      - 'release/aicspylibczi'
 
 jobs:
   deploy:
@@ -19,8 +22,8 @@ jobs:
       - name: Build manylinux Python wheels
         uses: allen-cell-animated/python-wheels-manylinux-build@v1.1
         with:
-          python-versions: 'cp37-cp37m cp38-cp38'
+          python-versions: 'cp36-37m cp37-cp37m cp38-cp38'
           build-requirements: 'cython numpy make cmake==3.17.3 twine wheel'
       - name: Upload Files
         run: |
-          ls dist/*.whl
+          twine upload --repository-url https://upload.pypi.org/legacy/ -u aicspypi -p '${{ secrets.PYPI_TOKEN }}' dist/*manylinux2010*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -22,7 +22,7 @@ jobs:
           python-versions: 'cp37-cp37m'
           system-packages: 'gcc-c++'
           build-requirements: 'cython numpy make cmake==3.17.3'
-          pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
+          pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH; which g++'
       - name: List Files
         run: |
           dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -20,11 +20,8 @@ jobs:
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-pypywheels/manylinux2010-pypy_x86_64
         with:
           python-versions: 'cp37-cp37m'
-          system-packages: 'gcc-c++'
           build-requirements: 'cython numpy make cmake==3.17.3'
-          pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH; which g++'
-        run: |
-          echo "${{ steps.tagName.outputs.tag }}"
+          pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
       - name: List Files
         run: |
-          dist/*-manylinux*.whl
+          ls dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -17,12 +17,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install twine
       - name: Build manylinux Python wheels
-        uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
+        uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010-pypy_x86_64
         with:
           python-versions: 'cp37-cp37m'
-          system-packages: 'gcc-c++'
           build-requirements: 'cython numpy make cmake==3.17.3'
-          pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH; which g++'
+          pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
       - name: List Files
         run: |
           dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -19,9 +19,9 @@ jobs:
       - name: Build manylinux Python wheels
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
         with:
-          python-versions: 'cp36-cp36m cp37-cp37m'
+          python-versions: 'cp37-cp37m'
           build-requirements: 'cython numpy'
-          pre-build-command: 'pip install cmake=3.14.3'
+          pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH; pip install cmake=3.14.3'
       - name: List Files
         run: |
           dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-versions: 'cp37-cp37m'
           build-requirements: 'cython numpy make cmake==3.17.3 twine wheel'
-          pre-build-command: 'bash ./script/docker_setup.sh'
+          pre-build-command: 'bash ./scripts/docker_setup.sh'
       - name: List Files
         run: |
           ls dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -1,0 +1,26 @@
+name: Python package build and publish
+on: push
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+          with:
+            submodules: true
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install twine
+      - name: Build manylinux Python wheels
+        uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
+        with:
+          python-versions: 'cp36-cp36m cp37-cp37m'
+          build-requirements: 'cython numpy'
+      - name: List Files
+        run: |
+          dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -17,11 +17,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install twine
       - name: Build manylinux Python wheels
-        uses: RalfG/python-wheels-manylinux-build@v0.3.1
+        uses: allen-cell-animated/python-wheels-manylinux-build@v1
         with:
           python-versions: 'cp37-cp37m'
           build-requirements: 'cython numpy make cmake==3.17.3 twine wheel'
-          pre-build-command: 'bash ./scripts/docker_setup.sh'
       - name: List Files
         run: |
           ls dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-versions: 'cp37-cp37m'
           build-requirements: 'cython numpy cmake==3.17.3'
-          pre-build-command: 'which python'
+          pre-build-command: 'which cmake'
       - name: List Files
         run: |
           dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -21,8 +21,7 @@ jobs:
         with:
           python-versions: 'cp37-cp37m'
           build-requirements: 'cython numpy make cmake==3.17.3 twine wheel'
-          package-path: 'aicspylibczi'
-          pre-build-command: 'bash aicspylibczi/script/docker_setup.sh'
+          pre-build-command: 'bash ./script/docker_setup.sh'
       - name: List Files
         run: |
           ls dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -20,8 +20,8 @@ jobs:
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
         with:
           python-versions: 'cp37-cp37m'
-          build-requirements: 'cython numpy cmake=3.14.3'
-          pre-build-command: 'which cmake; cmake --version'
+          build-requirements: 'cython numpy cmake==3.14.3'
+          pre-build-command: 'which python'
       - name: List Files
         run: |
           dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -20,7 +20,7 @@ jobs:
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
         with:
           python-versions: 'cp37-cp37m'
-          build-requirements: 'cython numpy cmake=3.14.3'
+          build-requirements: 'cython numpy cmake==3.14.3'
           pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
       - name: List Files
         run: |

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install twine
-          pip install cmake==3.13.3
+          pip install cmake==3.14.3
       - name: Build manylinux Python wheels
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
         with:

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -20,7 +20,7 @@ jobs:
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
         with:
           python-versions: 'cp37-cp37m'
-          build-requirements: 'cython numpy cmake==3.17.3'
+          build-requirements: 'cython numpy make cmake==3.17.3'
           pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
       - name: List Files
         run: |

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -20,7 +20,7 @@ jobs:
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
         with:
           python-versions: 'cp37-cp37m'
-          build-requirements: 'cython numpy cmake==3.14.3'
+          build-requirements: 'cython numpy cmake==3.17.3'
           pre-build-command: 'which python'
       - name: List Files
         run: |

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-versions: 'cp37-cp37m'
           build-requirements: 'cython numpy cmake==3.17.3'
-          pre-build-command: 'which cmake'
+          pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
       - name: List Files
         run: |
           dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -20,8 +20,8 @@ jobs:
         uses: RalfG/python-wheels-manylinux-build@v0.3.1
         with:
           python-versions: 'cp37-cp37m'
-          build-requirements: 'cython numpy make cmake==3.17.3'
-          pre-build-command: 'cmake --version'
+          build-requirements: 'cython numpy make cmake==3.17.3 twine wheel'
+          pre-build-command: 'bash script/docker_setup.sh'
       - name: List Files
         run: |
           ls dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -20,7 +20,7 @@ jobs:
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
         with:
           python-versions: 'cp37-cp37m'
-          system-packages: 'gcc.x86_64'
+          system-packages: 'gcc.x86_64 gcc-g++'
           build-requirements: 'cython numpy make cmake==3.17.3'
           pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
       - name: List Files

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        fetch-depth: 0
         with:
           submodules: true
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -6,8 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-          with:
-            submodules: true
+        with:
+          submodules: true
       - name: Set up Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -20,8 +20,8 @@ jobs:
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
         with:
           python-versions: 'cp37-cp37m'
-          build-requirements: 'cython numpy make cmake==3.17.3'
-          pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:/opt/rh/devtoolset-8/root/usr/bin:$PATH'
+          build-requirements: 'cython numpy make cmake==3.17.3 gcc g++'
+          pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
       - name: List Files
         run: |
           dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -20,7 +20,8 @@ jobs:
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
         with:
           python-versions: 'cp36-cp36m cp37-cp37m'
-          build-requirements: 'cython numpy cmake'
+          build-requirements: 'cython numpy'
+          pre-build-command: 'pip install cmake=3.14.3'
       - name: List Files
         run: |
           dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -20,8 +20,8 @@ jobs:
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
         with:
           python-versions: 'cp37-cp37m'
-          build-requirements: 'cython numpy'
-          pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH; pip install cmake=3.14.3'
+          build-requirements: 'cython numpy cmake=3.14.3'
+          pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
       - name: List Files
         run: |
           dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -16,12 +16,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install twine
-          pip install cmake==3.14.3
       - name: Build manylinux Python wheels
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
         with:
           python-versions: 'cp36-cp36m cp37-cp37m'
-          build-requirements: 'cython numpy cmake==3.14.3'
+          build-requirements: 'cython numpy cmake'
       - name: List Files
         run: |
           dist/*-manylinux*.whl

--- a/.github/workflows/PublishLinux.yml
+++ b/.github/workflows/PublishLinux.yml
@@ -20,7 +20,8 @@ jobs:
         uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
         with:
           python-versions: 'cp37-cp37m'
-          build-requirements: 'cython numpy make cmake==3.17.3 gcc g++'
+          system-packages: 'gcc-c++'
+          build-requirements: 'cython numpy make cmake==3.17.3'
           pre-build-command: 'export PATH=/opt/python/cp37-cp37m/bin:$PATH'
       - name: List Files
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/pybind/pybind11.git
 [submodule "libCZI"]
 	path = libCZI
-	url = https://github.com/zeiss-microscopy/libCZI.git
+	url = https://github.com/AllenCellModeling/libCZI.git

--- a/scripts/docker_setup.sh
+++ b/scripts/docker_setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export PATH=/opt/python/cp37-cp37m/bin:$PATH
+pip install cmake==3.17.3
+cmake --version
+which g++
+which python

--- a/scripts/docker_setup.sh
+++ b/scripts/docker_setup.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-export PATH=/opt/python/cp37-cp37m/bin:$PATH
-pip install cmake==3.17.3
-cmake --version
-which g++
-which python

--- a/setup.py
+++ b/setup.py
@@ -86,10 +86,13 @@ class CMakeBuild(build_ext):
             raise RuntimeError("CMake must be installed to build the following extensions: " +
                                ", ".join(e.name for e in self.extensions))
 
+        cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
         if platform.system() == "Windows":
             cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
             if cmake_version < '3.1.0':
                 raise RuntimeError("CMake >= 3.1.0 is required on Windows")
+        elif cmake_version < '3.1.0':
+            raise RuntimeError("CMake >= 3.1.0 is required on Windows")
 
         for ext in self.extensions:
             self.build_extension(ext)

--- a/setup.py
+++ b/setup.py
@@ -98,8 +98,7 @@ class CMakeBuild(build_ext):
 
     def build_extension(self, ext):
         path_var = os.environ.get('PATH')
-        print(f"val={Path(sys.executable).parent}")
-        path_var = os.pathsep.join(Path(sys.executable).parent, path_var)
+        path_var = Path(sys.executable).parent + ':' + path_var
         env = dict(os.environ, PATH=path_var)
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ class CMakeBuild(build_ext):
 
     def build_extension(self, ext):
         path_var = os.environ.get('PATH')
-        path_var = Path(sys.executable).parent + ':' + path_var
+        path_var = str(Path(sys.executable).parent) + ':' + path_var
         env = dict(os.environ, PATH=path_var)
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ class CMakeBuild(build_ext):
             self.build_extension(ext)
 
     def build_extension(self, ext):
-        path_var = os.environ.get('PATH', os.defpath)
+        path_var = os.environ.get('PATH')
         env = dict(os.environ, PATH=path_var)
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,

--- a/setup.py
+++ b/setup.py
@@ -98,8 +98,7 @@ class CMakeBuild(build_ext):
 
     def build_extension(self, ext):
         path_var = os.environ.get('PATH')
-        pth = Path(os.__file__)
-        print(f"pathlib Path={pth}")
+        path_var = os.pathsep.join(Path(sys.executable).parent, path_var)
         env = dict(os.environ, PATH=path_var)
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,7 @@ class CMakeBuild(build_ext):
             cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
             build_args += ['--', '-j2']
 
+        print(f"PATH={env['PATH']}")
         # env = os.environ.copy()
         env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
                                                               self.distribution.get_version())

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 
 import os
+from pathlib import Path
 import platform
 import re
 import subprocess
@@ -97,6 +98,8 @@ class CMakeBuild(build_ext):
 
     def build_extension(self, ext):
         path_var = os.environ.get('PATH')
+        pth = Path(os.__file__)
+        print(f"pathlib Path={pth}")
         env = dict(os.environ, PATH=path_var)
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ class CMakeExtension(Extension):
 class CMakeBuild(build_ext):
     def run(self):
         try:
-            out = subprocess.check_output(['cmake', '--version'])
+            out = subprocess.check_output(['/opt/python/cp37-cp37m/bin/cmake', '--version'])
         except OSError:
             raise RuntimeError("CMake must be installed to build the following extensions: " +
                                ", ".join(e.name for e in self.extensions))
@@ -91,8 +91,6 @@ class CMakeBuild(build_ext):
             cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
             if cmake_version < '3.1.0':
                 raise RuntimeError("CMake >= 3.1.0 is required on Windows")
-        elif cmake_version < '3.1.0':
-            raise RuntimeError("CMake >= 3.1.0 is required on Windows")
 
         for ext in self.extensions:
             self.build_extension(ext)
@@ -118,8 +116,8 @@ class CMakeBuild(build_ext):
                                                               self.distribution.get_version())
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
-        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
-        subprocess.check_call(['cmake', '--build', '.', '--target', '_aicspylibczi'] + build_args, cwd=self.build_temp)
+        subprocess.check_call(['/opt/python/cp37-cp37m/bin/cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
+        subprocess.check_call(['/opt/python/cp37-cp37m/bin/cmake', '--build', '.', '--target', '_aicspylibczi'] + build_args, cwd=self.build_temp)
 
 setup(
     name='aicspylibczi',

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ class CMakeExtension(Extension):
 class CMakeBuild(build_ext):
     def run(self):
         try:
-            out = subprocess.check_output(['/opt/python/cp37-cp37m/bin/cmake', '--version'])
+            out = subprocess.check_output(['cmake', '--version'])
         except OSError:
             raise RuntimeError("CMake must be installed to build the following extensions: " +
                                ", ".join(e.name for e in self.extensions))
@@ -96,6 +96,8 @@ class CMakeBuild(build_ext):
             self.build_extension(ext)
 
     def build_extension(self, ext):
+        path_var = os.environ.get('PATH', os.defpath)
+        env = dict(os.environ, PATH=path_var)
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
                       '-DPYTHON_EXECUTABLE=' + sys.executable]
@@ -111,13 +113,13 @@ class CMakeBuild(build_ext):
             cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
             build_args += ['--', '-j2']
 
-        env = os.environ.copy()
+        # env = os.environ.copy()
         env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
                                                               self.distribution.get_version())
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
-        subprocess.check_call(['/opt/python/cp37-cp37m/bin/cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
-        subprocess.check_call(['/opt/python/cp37-cp37m/bin/cmake', '--build', '.', '--target', '_aicspylibczi'] + build_args, cwd=self.build_temp)
+        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
+        subprocess.check_call(['cmake', '--build', '.', '--target', '_aicspylibczi'] + build_args, cwd=self.build_temp, env=env)
 
 setup(
     name='aicspylibczi',

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ class CMakeBuild(build_ext):
 
     def build_extension(self, ext):
         path_var = os.environ.get('PATH')
+        print(f"val={Path(sys.executable).parent}")
         path_var = os.pathsep.join(Path(sys.executable).parent, path_var)
         env = dict(os.environ, PATH=path_var)
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ class CMakeBuild(build_ext):
     def build_extension(self, ext):
         path_var = os.environ.get('PATH')
         path_var = str(Path(sys.executable).parent) + ':' + path_var
-        env = dict(os.environ, PATH=path_var)
+        env = dict(os.environ.copy(), PATH=path_var)
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
         cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
                       '-DPYTHON_EXECUTABLE=' + sys.executable]
@@ -115,8 +115,6 @@ class CMakeBuild(build_ext):
             cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
             build_args += ['--', '-j2']
 
-        print(f"PATH={env['PATH']}")
-        # env = os.environ.copy()
         env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
                                                               self.distribution.get_version())
         if not os.path.exists(self.build_temp):


### PR DESCRIPTION
This PR enables automated Linux builds for desired versions of python. 
There are some minor changes to setup.py but the bulk of what made it work were the modifications of `allen-cell-animated/python-wheels-manylinux-build`, specifically changing it to build via bdist_wheel. 