### PR TITLE
force cores to be a valid number

### DIFF
--- a/_aicspylibczi/Reader.cpp
+++ b/_aicspylibczi/Reader.cpp
@@ -290,12 +290,12 @@ namespace pylibczi {
       imageFactory.setMosaic(isMosaic());
       size_t memOffset = 0;
 
-      unsigned int number_of_cores = std::thread::hardware_concurrency();
-      if (number_of_cores - 1 < cores_) {
-          std::cout << "Cores exception requested " << cores_ << " but only " << number_of_cores << " available." << std::endl;
-          throw ThreadingRequestedCoresException(number_of_cores, cores_,
-              "Requested cores should be at most 1 less than the number of available cores.");
-      }
+      /*
+       * On windows the python code says there are far more cores than the C++ code. For that reason we have
+       * implemented this in such a way that it rescales to a workable value when necessary.
+       */
+      unsigned int min_cores = 1; // for the case when hardware_concurency fails and returns 0
+      unsigned int number_of_cores = std::max(min_cores, std::min(cores_, std::thread::hardware_concurrency()-1));
       {
           std::vector< std::future<bool> > jobs;
           Tasks tasks;

--- a/aicspylibczi/tests/test_czi_file.py
+++ b/aicspylibczi/tests/test_czi_file.py
@@ -160,7 +160,8 @@ def test_pixel_type(data_dir, fname, expected):
 
 
 @pytest.mark.parametrize("fname, args, expected", [
-    ('mosaic_test.czi', {'M': 0}, (1, 1, 1, 1, 1, 624, 924))
+    ('mosaic_test.czi', {'M': 0}, (1, 1, 1, 1, 1, 624, 924)),
+    ('mosaic_test.czi', {'M': 0, 'cores': 2000}, (1, 1, 1, 1, 1, 624, 924))
 ])
 def test_read_image_args(data_dir, fname, args, expected):
     czi = CziFile(data_dir / fname)


### PR DESCRIPTION
This bugfix adapts for odd behavior on windows systems where python and C++ calculate different numbers of cores. 

1) changed to smoothly handle the number of cores being invalid or 0 

2) implemented a test to make sure it adapts appropriately.