### PR TITLE
Fix/crash when no subblocks

### DIFF
--- a/_aicspylibczi/ImageFactory.cpp
+++ b/_aicspylibczi/ImageFactory.cpp
@@ -132,7 +132,7 @@ ImageFactory::sizeOfPixelType(PixelType pixel_type_)
     case PixelType::Bgr96Float:
       return sizeof(float);
     default:
-      throw PixelTypeException(pixel_type_, "Pixel Type unsupported by libCZI.");
+      throw PixelTypeException(pixel_type_, "sizeOfPixelType: Pixel Type unsupported by libCZI.");
   }
 }
 
@@ -149,8 +149,10 @@ ImageFactory::numberOfSamples(libCZI::PixelType pixel_type_)
     case PixelType::Bgr48:
     case PixelType::Bgr96Float:
       return 3;
+    case PixelType::Invalid:
+      return 0;
     default:
-      throw PixelTypeException(pixel_type_, "Pixel Type unsupported by libCZI.");
+      throw PixelTypeException(pixel_type_, "numberOfSamples: Pixel Type unsupported by libCZI.");
   }
 }
 

--- a/_aicspylibczi/Reader.h
+++ b/_aicspylibczi/Reader.h
@@ -355,7 +355,7 @@ private:
   libCZI::IntRect getSceneYXSize(int scene_index_ = -1)
   {
     std::vector<libCZI::IntRect> matches = getAllSceneYXSize(scene_index_);
-    return matches.front();
+    return matches.empty() ? libCZI::IntRect{ 0,0,0,0 } : matches.front();
   }
 
   /*!


### PR DESCRIPTION
AICS has some old files which apparently have metadata but no subblocks.  It is thought that they were container files with expected pixel data in associated additional files, but they have now become isolated and it's ~impossible to recover the pixel data. The goal is to still be able to get metadata out.

The code change here prevents aicspylibczi from crashing on such files, and also prevents an exception from being raised due to the PixelType = Invalid.  These code changes only affect attempting to first open the file and collect dimension info and metadata.

There needs to be an accompanying change in aicsimageio's czi_reader to complete this support.