### PR TITLE
use m2r2 instead of deprecated m2r

### DIFF
--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -40,7 +40,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
     "sphinx.ext.mathjax",
-    "m2r",
+    "m2r2",
 ]
 
 # Control napoleon

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ dev_requirements = [
     "coverage>=5.0a4",
     "flake8>=3.7.7",
     "ipython>=7.5.0",
-    "m2r>=0.2.1",
+    "m2r2>=0.2.7",
     "pytest>=4.3.0",
     "pytest-cov==2.6.1",
     "pytest-raises>=0.10",


### PR DESCRIPTION
Trying to fix the build-docs step.