### PR TITLE
add python 3.10

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install Dependencies
         run: |
           pip install --upgrade pip

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -9,11 +9,11 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: true
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.9
       - name: Install Dependencies

--- a/.github/workflows/cpp-build-main.yml
+++ b/.github/workflows/cpp-build-main.yml
@@ -40,7 +40,7 @@ jobs:
             cc: "clang", cxx: "clang++"
           }
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: true
       - name: build and test

--- a/.github/workflows/cpp-build-pr.yml
+++ b/.github/workflows/cpp-build-pr.yml
@@ -34,7 +34,7 @@ jobs:
             cc: "clang", cxx: "clang++"
           }
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: true
       - name: build and test

--- a/.github/workflows/py-build-main.yml
+++ b/.github/workflows/py-build-main.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
         os: [ubuntu-latest, windows-latest, macOS-10.15, macOS-11.0]
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
       - name: setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -44,7 +44,7 @@ jobs:
         with:
           submodules: true
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.9
       - name: Install dependencies

--- a/.github/workflows/py-build-main.yml
+++ b/.github/workflows/py-build-main.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/py-build-main.yml
+++ b/.github/workflows/py-build-main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         os: [ubuntu-latest, windows-latest, macOS-10.15, macOS-11.0]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/py-build-pr.yml
+++ b/.github/workflows/py-build-pr.yml
@@ -34,10 +34,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/py-build-pr.yml
+++ b/.github/workflows/py-build-pr.yml
@@ -6,15 +6,15 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
         os: [ubuntu-latest, windows-latest, macos-10.15, macos-11.0]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: true
       - name: setup python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install aicspylibczi
@@ -31,11 +31,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: true
       - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.7
       - name: Install dependencies

--- a/.github/workflows/py-build-pr.yml
+++ b/.github/workflows/py-build-pr.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         os: [ubuntu-latest, windows-latest, macos-10.15, macos-11.0]
 
     steps:

--- a/_aicspylibczi/pb_helpers.h
+++ b/_aicspylibczi/pb_helpers.h
@@ -30,7 +30,7 @@ memoryToNpArray(pylibczi::ImagesContainerBase* bptr_, std::vector<std::pair<char
 {
   pylibczi::ImagesContainer<T>* tptr = bptr_->getBaseAsTyped<T>();
 
-  std::vector<ssize_t> shape(charSizes_.size(), 0);
+  std::vector<Py_ssize_t> shape(charSizes_.size(), 0);
   std::transform(
     charSizes_.begin(), charSizes_.end(), shape.begin(), [](const std::pair<char, size_t>& a_) { return a_.second; });
 


### PR DESCRIPTION
add Python 3.10,  bump versions of core ghactions (setup-python and checkout), and bump version of pybind11 to latest release 2.9

Should I change the Python version under which the gh-actions run?  I suppose it can go to 3.10 also?