### PR TITLE
fixing pip install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,7 @@
+include CONTRIBUTING.md
+include LICENSE
+include README.md
+
 include CMakeLists.txt
 recursive-include _aicspylibczi *.cpp *.h *.hpp *.c *.py *.pyx *.pxd *.pxi *.pyd *.dll *.so *.d
 recursive-include libCZI *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include CMakeLists.txt
+recursive-include _aicspylibczi *.cpp *.h *.hpp *.c *.py *.pyx *.pxd *.pxi *.pyd *.dll *.so *.d
+recursive-include libCZI *
+recursive-include pybind11 *

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ requirements = [
 ]
 
 test_requirements = [
-    "codecov",
     "flake8",
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
pip install of 3.1.0 seems somehow broken especially with python 3.11.  Trying to add a MANIFEST.in to fix the sdist