### PR TITLE
Fix/sdist

### DIFF
--- a/.github/workflows/py-build-pr.yml
+++ b/.github/workflows/py-build-pr.yml
@@ -29,9 +29,8 @@ jobs:
       - name: Check install from sdist
         run: |
           MY_VERSION=$(python setup.py --version)
-          # echo "MY_VERSION=$(python setup.py --version)" >> $GITHUB_OUTPUT
           pip install dist/aicspylibczi-$MY_VERSION.tar.gz
-
+        shell: bash
       - name: Upload codecov
         uses: codecov/codecov-action@v3
 

--- a/.github/workflows/py-build-pr.yml
+++ b/.github/workflows/py-build-pr.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build the sdist
         run: pipx run build --sdist
       - name: Check install from sdist
-        run: pip install dist/*
+        run: pip install dist/*.tar.gz
 
       - name: Upload codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/py-build-pr.yml
+++ b/.github/workflows/py-build-pr.yml
@@ -24,6 +24,11 @@ jobs:
       - name: Test with pytest
         run: |
           pytest -n1 --cov-report xml --cov=aicspylibczi aicspylibczi/tests
+      - name: Build the sdist
+        run: pipx run build --sdist
+      - name: Check install from sdist
+        run: pip install dist/*
+
       - name: Upload codecov
         uses: codecov/codecov-action@v3
 

--- a/.github/workflows/py-build-pr.yml
+++ b/.github/workflows/py-build-pr.yml
@@ -27,7 +27,10 @@ jobs:
       - name: Build the sdist
         run: pipx run build --sdist
       - name: Check install from sdist
-        run: pip install --force-reinstall --no-index --find-links=./dist aicspylibczi
+        run: |
+          MY_VERSION=$(python setup.py --version)
+          # echo "MY_VERSION=$(python setup.py --version)" >> $GITHUB_OUTPUT
+          pip install dist/aicspylibczi-$MY_VERSION.tar.gz
 
       - name: Upload codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/py-build-pr.yml
+++ b/.github/workflows/py-build-pr.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build the sdist
         run: pipx run build --sdist
       - name: Check install from sdist
-        run: pip install dist/*.tar.gz
+        run: pip install --force-reinstall --no-index --find-links=./dist aicspylibczi
 
       - name: Upload codecov
         uses: codecov/codecov-action@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ ELSE()
 
 ENDIF(WIN32)
 
-SET(pybind11_DIR pybind11)
+SET(pybind11_DIR ${CMAKE_CURRENT_LIST_DIR}/pybind11)
 
 add_compile_definitions(_LIBCZISTATICLIB)
 add_compile_definitions(LIBCZI_BUILD_UNITTESTS=OFF)
@@ -38,7 +38,6 @@ add_compile_definitions(LIBCZI_BUILD_CZICMD=OFF)
 add_subdirectory(libCZI)
 add_subdirectory(pybind11)
 
-find_package(pybind11)
 message(STATUS "Found pybind11 v${pybind11_VERSION}: ${pybind11_INCLUDE_DIRS}")
 
 set(PYLIBCZI_C_SRC_HEADERS _aicspylibczi/Reader.h _aicspylibczi/helper_algorithms.h _aicspylibczi/exceptions.h _aicspylibczi/inc_libCZI.h

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,8 @@ include LICENSE
 include README.md
 
 include CMakeLists.txt
+include main.cpp
+recursive-include c_tests *.txt *.cpp *.h *.hpp *.c *.py *.pyx *.pxd *.pxi *.pyd *.dll *.so *.d
 recursive-include _aicspylibczi *.cpp *.h *.hpp *.c *.py *.pyx *.pxd *.pxi *.pyd *.dll *.so *.d
 recursive-include libCZI *
 recursive-include pybind11 *


### PR DESCRIPTION
the sdist did not seem to be complete just yet.
For reference in testing the sdist:
```
pipx run build --sdist  
pip install dist/aicspylibczi-3.1.1.tar.gz
```

I did this slightly lazily by adding the c_test code that was included in the cmake files, rather than messing with the cmake config.  But the c_tests are never run in the sdist, nor are the test resources copied, so this should be a very small amount of useless code in the source dist.

This is a step toward helping with https://github.com/conda-forge/staged-recipes/pull/18157