### PR TITLE
Make GPLv3 available in metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,10 @@ setup(
     long_description_content_type="text/markdown",
     include_package_data=True,
     keywords="aicspylibczi, allen cell, imaging, computational biology",
+    license="GPLv3",
+    classifiers=[
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    ],
     ext_modules=[CMakeExtension('_aicspylibczi')],
     packages=['aicspylibczi'],
     cmdclass=dict(build_ext=CMakeBuild),


### PR DESCRIPTION
This is for tools like "pip show" or pip-licenses to correctly report the license.

Untested, at the moment