### PR TITLE
Fix build and clean up warnings

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: "3.10"
       - name: Install Dependencies
         run: |
-          pip install --upgrade pip
+          pip install --upgrade pip setuptools
           pip install .[dev]
       - name: Generate Docs
         env:

--- a/.github/workflows/py-build-main.yml
+++ b/.github/workflows/py-build-main.yml
@@ -9,7 +9,7 @@ env:
   CIBW_TEST_COMMAND: pytest {project}/aicspylibczi/tests
   CIBW_TEST_EXTRAS: test
   # skip python 3.6, 32-bit builds, and PyPy
-  CIBW_SKIP: cp36-* *-win32 *-manylinux_i686 pp*
+  CIBW_SKIP: cp36-* cp37-* *-win32 *-manylinux_i686 pp*
 
 name: Python Build Main
 jobs:
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/py-build-main.yml
+++ b/.github/workflows/py-build-main.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools
           pip install .[test]
       - name: Test with pytest
         run: |
@@ -50,7 +50,7 @@ jobs:
           python-version: "3.10"
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools
           pip install .[test]
       - name: Lint with flake8
         run: |

--- a/.github/workflows/py-build-main.yml
+++ b/.github/workflows/py-build-main.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/py-build-pr.yml
+++ b/.github/workflows/py-build-pr.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/py-build-pr.yml
+++ b/.github/workflows/py-build-pr.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/.github/workflows/py-build-pr.yml
+++ b/.github/workflows/py-build-pr.yml
@@ -8,9 +8,6 @@ jobs:
       matrix:
         python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        exclude:
-          - os: windows-latest
-            python-version: 3.8
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/py-build-pr.yml
+++ b/.github/workflows/py-build-pr.yml
@@ -7,7 +7,7 @@ jobs:
       max-parallel: 6
       matrix:
         python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/py-build-pr.yml
+++ b/.github/workflows/py-build-pr.yml
@@ -8,6 +8,9 @@ jobs:
       matrix:
         python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        exclude:
+          - os: windows-latest
+            python-version: 3.8
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/py-build-pr.yml
+++ b/.github/workflows/py-build-pr.yml
@@ -23,7 +23,7 @@ jobs:
           pip install .[test]
       - name: Test with pytest
         run: |
-          pytest -n1 --cov-report xml --cov=aicspylibczi aicspylibczi/tests
+          pytest --cov-report xml --cov=aicspylibczi aicspylibczi/tests
       - name: Build the sdist
         run: pipx run build --sdist
       - name: Check install from sdist

--- a/.github/workflows/py-build-pr.yml
+++ b/.github/workflows/py-build-pr.yml
@@ -7,7 +7,7 @@ jobs:
       max-parallel: 6
       matrix:
         python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/py-build-pr.yml
+++ b/.github/workflows/py-build-pr.yml
@@ -47,7 +47,7 @@ jobs:
           python-version: "3.10"
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools
           pip install .[test]
       - name: Lint with flake8
         run: |

--- a/.github/workflows/py-build-pr.yml
+++ b/.github/workflows/py-build-pr.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install aicspylibczi
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip setuptools
           pip install .[test]
       - name: Test with pytest
         run: |

--- a/_aicspylibczi/CSimpleStreamImplFromFd.cpp
+++ b/_aicspylibczi/CSimpleStreamImplFromFd.cpp
@@ -19,7 +19,6 @@ namespace pb_helpers {
 CSimpleStreamImplFromFd::CSimpleStreamImplFromFd(int file_descriptor_)
   : libCZI::IStream()
 {
-  std::cout << "CSimpleStreamImplFromFd::CSimpleStreamImplFromFd(" << file_descriptor_ << ")" << std::endl;
 #ifdef _WIN32
   int dupDesc = _dup(file_descriptor_);
   if (dupDesc == -1) {

--- a/_aicspylibczi/CSimpleStreamImplFromFd.cpp
+++ b/_aicspylibczi/CSimpleStreamImplFromFd.cpp
@@ -22,13 +22,17 @@ CSimpleStreamImplFromFd::CSimpleStreamImplFromFd(int file_descriptor_)
   std::cout << "CSimpleStreamImplFromFd::CSimpleStreamImplFromFd(" << file_descriptor_ << ")" << std::endl;
 #ifdef _WIN32
   int dupDesc = _dup(file_descriptor_);
+  if (dupDesc == -1) {
+    throw pylibczi::FilePtrException("Reader class could not dup the file descriptor!");
+  }
   m_fp = _fdopen(dupDesc, "r");
 #else
   int dupDesc = dup(file_descriptor_);
   m_fp = fdopen(dupDesc, "r");
 #endif
-  if (m_fp == nullptr)
+  if (m_fp == nullptr) {
     throw pylibczi::FilePtrException("Reader class received a bad FILE *!");
+  }
 }
 
 void

--- a/_aicspylibczi/CSimpleStreamImplFromFd.cpp
+++ b/_aicspylibczi/CSimpleStreamImplFromFd.cpp
@@ -40,6 +40,7 @@ CSimpleStreamImplFromFd::Read(std::uint64_t offset_,
                               std::uint64_t size_,
                               std::uint64_t* bytes_read_ptr_)
 {
+  std::unique_lock<std::mutex> lck(m_mutex);
 #ifdef _WIN32
   int r = _fseeki64(this->m_fp, offset_, SEEK_SET);
 #else

--- a/_aicspylibczi/CSimpleStreamImplFromFd.cpp
+++ b/_aicspylibczi/CSimpleStreamImplFromFd.cpp
@@ -41,7 +41,6 @@ CSimpleStreamImplFromFd::Read(std::uint64_t offset_,
                               std::uint64_t size_,
                               std::uint64_t* bytes_read_ptr_)
 {
-  std::unique_lock<std::mutex> lck(m_mutex);
 #ifdef _WIN32
   int r = _fseeki64(this->m_fp, offset_, SEEK_SET);
 #else

--- a/_aicspylibczi/CSimpleStreamImplFromFd.h
+++ b/_aicspylibczi/CSimpleStreamImplFromFd.h
@@ -22,7 +22,6 @@ class CSimpleStreamImplFromFd : public libCZI::IStream
 {
 private:
   FILE* m_fp;
-  std::mutex m_mutex;
 
 public:
   CSimpleStreamImplFromFd() = delete;

--- a/_aicspylibczi/CSimpleStreamImplFromFd.h
+++ b/_aicspylibczi/CSimpleStreamImplFromFd.h
@@ -22,6 +22,7 @@ class CSimpleStreamImplFromFd : public libCZI::IStream
 {
 private:
   FILE* m_fp;
+  std::mutex m_mutex;
 
 public:
   CSimpleStreamImplFromFd() = delete;

--- a/_aicspylibczi/Reader.cpp
+++ b/_aicspylibczi/Reader.cpp
@@ -112,7 +112,7 @@ Reader::dimSizes()
 
   pixelType();
   if (ImageFactory::numberOfSamples(m_pixelType) > 1)
-    ans.push_back(ImageFactory::numberOfSamples(m_pixelType));
+    ans.push_back((int)ImageFactory::numberOfSamples(m_pixelType));
 
   return ans;
 }
@@ -378,7 +378,6 @@ Reader::readSubblockMeta(libCZI::CDimCoordinate& plane_coord_, int index_m_)
   return metaSubblocks;
 }
 
-
 // private methods
 
 Reader::SubblockIndexVec
@@ -443,7 +442,10 @@ Reader::isValidRegion(const libCZI::IntRect& in_box_, const libCZI::IntRect& czi
 }
 
 ImagesContainerBase::ImagesContainerBasePtr
-Reader::readMosaic(libCZI::CDimCoordinate plane_coord_, float scale_factor_, libCZI::IntRect im_box_, libCZI::RgbFloatColor backGroundColor_)
+Reader::readMosaic(libCZI::CDimCoordinate plane_coord_,
+                   float scale_factor_,
+                   libCZI::IntRect im_box_,
+                   libCZI::RgbFloatColor backGroundColor_)
 {
   // handle the case where the function was called with region=None (default to all)
   if (im_box_.w == -1 && im_box_.h == -1)
@@ -470,8 +472,7 @@ Reader::readMosaic(libCZI::CDimCoordinate plane_coord_, float scale_factor_, lib
   options.backGroundColor = backGroundColor_;
 
   // multiTile accessor is not compatible with S, it composites the Scenes and the mIndexs together
-  auto multiTileComposite = accessor->Get(im_box_, &plane_coord_, scale_factor_,
-                                         &options);
+  auto multiTileComposite = accessor->Get(im_box_, &plane_coord_, scale_factor_, &options);
 
   libCZI::IntSize size = multiTileComposite->GetSize();
   size_t pixels_in_image = size.h * size.w * bgrScaling;

--- a/_aicspylibczi/TypedImage.h
+++ b/_aicspylibczi/TypedImage.h
@@ -131,7 +131,7 @@ TypedImage<T>::loadImage(const std::shared_ptr<libCZI::IBitmapData>& bitmap_ptr_
     // This mostly handles scaled mosaic images
     size_t pixelsPerRow = samples_per_pixel_ * size_.w;
     size_t bytesPerRow = pixelsPerRow * sizeof(T);
-    for (int j = 0; j < size_.h; j++) {
+    for (uint32_t j = 0; j < size_.h; j++) {
       std::memcpy(
         m_array + j * pixelsPerRow, (void*)((char*)(lckScoped.ptrDataRoi) + j * lckScoped.stride), bytesPerRow);
     }

--- a/_aicspylibczi/pb_caster_BytesIO.h
+++ b/_aicspylibczi/pb_caster_BytesIO.h
@@ -26,6 +26,7 @@ public:
    */
   bool load(handle src_, bool)
   {
+    std::cout << "load called with " << src_.ptr() << std::endl;
     /* Extract PyObject from handle */
     PyObject* source = src_.ptr();
 

--- a/_aicspylibczi/pb_caster_BytesIO.h
+++ b/_aicspylibczi/pb_caster_BytesIO.h
@@ -20,7 +20,7 @@ public:
   PYBIND11_TYPE_CASTER(std::shared_ptr<libCZI::IStream>, _("IOBufferedReader"));
 
   /**
-   * Conversion part 1 (Python->C++): convert a PyObject into a inty
+   * Conversion part 1 (Python->C++): convert a PyObject into a std::shared_ptr<libCZI::IStream>
    * instance or return false upon failure. The second argument
    * indicates whether implicit conversions should be applied.
    */

--- a/_aicspylibczi/pb_caster_BytesIO.h
+++ b/_aicspylibczi/pb_caster_BytesIO.h
@@ -26,7 +26,6 @@ public:
    */
   bool load(handle src_, bool)
   {
-    std::cout << "load called with " << src_.ptr() << std::endl;
     /* Extract PyObject from handle */
     PyObject* source = src_.ptr();
 

--- a/c_tests/test_Reader.cpp
+++ b/c_tests/test_Reader.cpp
@@ -65,7 +65,8 @@ class CziCreator
 public:
   CziCreator()
     : m_czi(new pylibczi::Reader(L"resources/s_1_t_1_c_1_z_1.czi"))
-  {}
+  {
+  }
   pylibczi::Reader* get() { return m_czi.get(); }
 };
 
@@ -76,7 +77,8 @@ class CziCreator2
 public:
   CziCreator2()
     : m_czi(new pylibczi::Reader(L"resources/s_3_t_1_c_3_z_5.czi"))
-  {}
+  {
+  }
   pylibczi::Reader* get() { return m_czi.get(); }
 };
 
@@ -87,7 +89,8 @@ class CziCreatorOrder
 public:
   CziCreatorOrder()
     : m_czi(new pylibczi::Reader(L"resources/CD_s_1_t_3_c_2_z_5.czi"))
-  {}
+  {
+  }
   pylibczi::Reader* get() { return m_czi.get(); }
 };
 
@@ -99,7 +102,8 @@ public:
   CziCreatorIStream()
     : m_czi()
   {
-    auto fp = std::shared_ptr<libCZI::IInputOutputStream>(libCZI::CreateInputOutputStreamForFile(L"resources/s_1_t_1_c_1_z_1.czi"));
+    auto fp = std::shared_ptr<libCZI::IInputOutputStream>(
+      libCZI::CreateInputOutputStreamForFile(L"resources/s_1_t_1_c_1_z_1.czi"));
     m_czi = std::make_unique<pylibczi::Reader>(fp);
   }
   pylibczi::Reader* get() { return m_czi.get(); }
@@ -114,7 +118,8 @@ class CziCreatorBig
 public:
   CziCreatorBig()
     : m_czi(new pylibczi::Reader(L"/Users/jamies/Data/20190425_S08_001-04-Scene-4-P3-B03.czi"))
-  {}
+  {
+  }
   pylibczi::Reader* get() { return m_czi.get(); }
 };
 
@@ -125,7 +130,8 @@ class CziCreatorBigM
 public:
   CziCreatorBigM()
     : m_czi(new pylibczi::Reader(L"/Users/jamies/Data/20190614_C01_001.czi"))
-  {}
+  {
+  }
   pylibczi::Reader* get() { return m_czi.get(); }
 };
 #endif
@@ -137,7 +143,8 @@ class CziCreator4
 public:
   CziCreator4()
     : m_czi(new pylibczi::Reader(L"resources/s_1_t_10_c_3_z_1.czi"))
-  {}
+  {
+  }
   pylibczi::Reader* get() { return m_czi.get(); }
 };
 
@@ -148,7 +155,8 @@ class CziCreator5
 public:
   CziCreator5()
     : m_czi(new pylibczi::Reader(L"resources/Multiscene_CZI_3Scenes.czi"))
-  {}
+  {
+  }
   pylibczi::Reader* get() { return m_czi.get(); }
 };
 
@@ -159,7 +167,8 @@ class CziCreatorTiles
 public:
   CziCreatorTiles()
     : m_czi(new pylibczi::Reader(L"resources/tiles.czi"))
-  {}
+  {
+  }
   pylibczi::Reader* get() { return m_czi.get(); }
 };
 
@@ -170,7 +179,8 @@ class CziCreatorTilesTZ
 public:
   CziCreatorTilesTZ()
     : m_czi(new pylibczi::Reader(L"resources/tiles_time_z.czi"))
-  {}
+  {
+  }
   pylibczi::Reader* get() { return m_czi.get(); }
 };
 
@@ -181,7 +191,8 @@ class CziCreatorTilesZ
 public:
   CziCreatorTilesZ()
     : m_czi(new pylibczi::Reader(L"resources/tiles_z.czi"))
-  {}
+  {
+  }
   pylibczi::Reader* get() { return m_czi.get(); }
 };
 
@@ -321,7 +332,8 @@ class CziMCreator
 public:
   CziMCreator()
     : m_czi(new pylibczi::Reader(L"resources/mosaic_test.czi"))
-  {}
+  {
+  }
   pylibczi::Reader* get() { return m_czi.get(); }
 };
 
@@ -385,7 +397,7 @@ TEST_CASE_METHOD(CziMCreator, "test_mosaic_readScaled", "[Reader_mosaic_readScal
 {
   auto czi = get();
   auto c_dims = libCZI::CDimCoordinate{ { libCZI::DimensionIndex::C, 0 } };
-  auto imCont = czi->readMosaic(c_dims, 0.1);
+  auto imCont = czi->readMosaic(c_dims, 0.1f);
   auto imvec = imCont->images();
   REQUIRE(imvec.size() == 1);
 }
@@ -414,7 +426,8 @@ class CziBgrCreator
 public:
   CziBgrCreator()
     : m_czi(new pylibczi::Reader(L"resources/RGB-8bit.czi"))
-  {}
+  {
+  }
   pylibczi::Reader* get() { return m_czi.get(); }
   const std::vector<int>& planeZeroFirstTen() { return m_firstPlaneFirstTen; }
   const std::vector<int>& planeOneFirstTen() { return m_secondPlaneFirstTen; }
@@ -532,7 +545,8 @@ class CziBgrCreator2
 public:
   CziBgrCreator2()
     : m_czi(new pylibczi::Reader(L"resources/RGB-multichannel.czi"))
-  {}
+  {
+  }
   pylibczi::Reader* get() { return m_czi.get(); }
 };
 

--- a/c_tests/test_main.cpp
+++ b/c_tests/test_main.cpp
@@ -4,10 +4,10 @@
 
 namespace py = pybind11;
 
+py::scoped_interpreter guard{};
 
 TEST_CASE("cast_test", "Is FILE * default constructible")
 {
-  py::scoped_interpreter guard{};
 
   REQUIRE(std::is_default_constructible<FILE*>());
   // REQUIRE(std::is_default_constructible<std::istream>()); // istream is NOT

--- a/c_tests/test_main.cpp
+++ b/c_tests/test_main.cpp
@@ -4,10 +4,11 @@
 
 namespace py = pybind11;
 
-py::scoped_interpreter guard{};
 
 TEST_CASE("cast_test", "Is FILE * default constructible")
 {
+  py::scoped_interpreter guard{};
+
   REQUIRE(std::is_default_constructible<FILE*>());
   // REQUIRE(std::is_default_constructible<std::istream>()); // istream is NOT
   // default constructible/**/!

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ test_requirements = [
     "pytest",
     "pytest-cov",
     "pytest-raises",
-    "pytest-xdist==3.5.0",
 ]
 
 dev_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ test_requirements = [
     "pytest",
     "pytest-cov",
     "pytest-raises",
-    "pytest-xdist",
+    "pytest-xdist==3.5.0",
 ]
 
 dev_requirements = [

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ exclude = pybind11,libCZI,_aicspylibczi,c_tests,docs,CMakeLists.txt,codecov.yml,
 
 [tox]
 skipsdist = True
-envlist = py38, py39, py310, py311, lint
+envlist = py38, py39, py310, py311, py312, lint
 
 [pytest]
 markers =


### PR DESCRIPTION
A couple months ago the build started failing.  I went in and started to track down why.

 * remove Python 3.7 from builds and add Python 3.12.
 * for some reason pytest-xdist 3.6.1 broke our Windows tests, but xdist 3.5.0 was working fine.  I have removed it for now as xdist was being used with -n1 which is one single worker anyway, kind of defeating the point of xdist.   I still don't know exactly why xdist's new version caused failures in windows but not mac or linux.

Bonus:  I fixed some minor type warnings in C++ compilation just for cleanup. Also added a bit more error checking.

 