### PR TITLE
use myst_parser instead of m2r2

### DIFF
--- a/.github/workflows/build-docs-pr.yml
+++ b/.github/workflows/build-docs-pr.yml
@@ -1,9 +1,6 @@
 name: Docs
 
-on:
-  push:
-    branches:
-      - main
+on: [pull_request]
 
 jobs:
   docs:
@@ -29,10 +26,3 @@ jobs:
           cmake ..
           cmake --build . --target docs
         shell: bash
-      - name: Publish Docs
-        uses: JamesIves/github-pages-deploy-action@releases/v3
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BASE_BRANCH: main
-          BRANCH: gh-pages
-          FOLDER: cmake_build_debug/docs/html

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
 
 jobs:
   docs:

--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ dummy_test.py
 *.ipynb
 .DS_Store
 cmake-build-debug/
+cmake_build_debug/

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -18,7 +18,7 @@
 # relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
 #
-import datetime
+from datetime import datetime
 import os
 import sys
 

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -46,7 +46,8 @@ extensions = [
 
 # Control napoleon
 napoleon_google_docstring = False
-napolean_include_init_with_doc = True
+napoleon_numpy_docstring = True
+napoleon_include_init_with_doc = True
 napoleon_use_ivar = True
 napoleon_use_param = False
 
@@ -61,7 +62,7 @@ templates_path = ["_templates"]
 #
 source_suffix = {
     ".rst": "restructuredtext",
-    ".txt": "markdown",
+    # ".txt": "markdown",
     ".md": "markdown",
 }
 

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -18,6 +18,7 @@
 # relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
 #
+import datetime
 import os
 import sys
 
@@ -40,7 +41,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
     "sphinx.ext.mathjax",
-    "m2r2",
+    "myst_parser",
 ]
 
 # Control napoleon
@@ -69,7 +70,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"aicspylibczi"
-copyright = u'2019, Allen Institute for Cell Science'
+project_copyright = f'2019-{datetime.now().year}, Allen Institute for Cell Science'
 author = u"Allen Institute for Cell Science"
 
 # The version info for the project you"re documenting, acts as replacement

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,1 +1,2 @@
-.. mdinclude:: ../CONTRIBUTING.md
+.. include:: ../CONTRIBUTING.md
+   :parser: myst_parser.docutils_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,7 +33,8 @@ Welcome to aicspylibczi's documentation!
    Package modules <modules>
    contributing
 
-.. mdinclude:: ../README.md
+.. include:: ../README.md
+   :parser: myst_parser.docutils_
 
 
 Indices and tables

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ dev_requirements = [
     "coverage>=5.0a4",
     "flake8>=3.7.7",
     "ipython>=7.5.0",
-    "m2r2>=0.2.7",
+    "myst-parser>=4.0.0",
     "pytest>=4.3.0",
     "pytest-cov==2.6.1",
     "pytest-raises>=0.10",


### PR DESCRIPTION
m2r2 is a Sphinx plugin parser for markdown format.  
m2r2 is no longer actively maintained, and one of its dependencies, docutils has updated and now breaks m2r2.
See this build script failure:  https://github.com/AllenCellModeling/aicspylibczi/actions/runs/11921902785

It was either pin docutils or try something new.  myst_parser is a more current replacement.
