### PR TITLE
fix a few build warnings or errors

### DIFF
--- a/.github/workflows/build-docs-pr.yml
+++ b/.github/workflows/build-docs-pr.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install Dependencies
         run: |
           pip install --upgrade pip setuptools

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install Dependencies
         run: |
           pip install --upgrade pip setuptools

--- a/.github/workflows/py-build-main.yml
+++ b/.github/workflows/py-build-main.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools
@@ -99,7 +99,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: pypa/cibuildwheel@v2.19.2
+      - uses: pypa/cibuildwheel@v2.23.2
         env:
           CIBW_BUILD: "*-${{ matrix.cibw-arch }}"
           CIBW_BEFORE_ALL_LINUX: yum install -y zlib-devel libpng-devel

--- a/.github/workflows/py-build-pr.yml
+++ b/.github/workflows/py-build-pr.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.9, "3.10", 3.11, 3.12, 3.13]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_MACOSX_RPATH 1)
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,9 +22,6 @@ replace = {new_version}
 search = {current_version}
 replace = {new_version}
 
-[bdist_wheel]
-universal = 1
-
 [flake8]
 exclude = docs
 max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -114,10 +114,8 @@ setup(
     long_description_content_type="text/markdown",
     include_package_data=True,
     keywords="aicspylibczi, allen cell, imaging, computational biology",
-    license="GPLv3",
-    classifiers=[
-        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
-    ],
+    license="GPL-3.0-or-later",
+    classifiers=[],
     ext_modules=[CMakeExtension('_aicspylibczi')],
     packages=['aicspylibczi'],
     cmdclass=dict(build_ext=CMakeBuild),


### PR DESCRIPTION
trying to deal with some build warnings, deprecations, and cmake error.

* run actions in python 3.12
* remove python 3.8 support
* add python 3.13 support
* fix warnings about bdist_wheel universal and license classifier string