### PR TITLE
autoformat and replace AllenCellModeling with bioio-devs

### DIFF
--- a/.github/workflows/py-build-main.yml
+++ b/.github/workflows/py-build-main.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: pypa/cibuildwheel@v2.23.2
+      - uses: pypa/cibuildwheel@v2.23.4
         env:
           CIBW_BUILD: "*-${{ matrix.cibw-arch }}"
           CIBW_BEFORE_ALL_LINUX: yum install -y zlib-devel libpng-devel

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # aicspylibczi
 
-[![C++ Build & Test](https://github.com/AllenCellModeling/aicspylibczi/workflows/C%2B%2B%20Main%20Build/badge.svg)](https://github.com/AllenCellModeling/aicspylibczi/actions)
-[![Python Build & Test](https://github.com/AllenCellModeling/aicspylibczi/workflows/Python%20Build%20Main/badge.svg)](https://github.com/AllenCellModeling/aicspylibczi/actions)
-[![License: GPLv3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://github.com/AllenCellModeling/aicspylibczi/blob/master/LICENSE)
+[![C++ Build & Test](https://github.com/bioio-devs/aicspylibczi/workflows/C%2B%2B%20Main%20Build/badge.svg)](https://github.com/bioio-devs/aicspylibczi/actions)
+[![Python Build & Test](https://github.com/bioio-devs/aicspylibczi/workflows/Python%20Build%20Main/badge.svg)](https://github.com/bioio-devs/aicspylibczi/actions)
+[![License: GPLv3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://github.com/bioio-devs/aicspylibczi/blob/master/LICENSE)
 
 Python module to expose [libCZI](https://github.com/zeiss-microscopy/libCZI) functionality for reading (subset of) Zeiss
 CZI files and meta-data. We only support 64bit architectures currently if you desperately need 32 bit support please make an issue or modify the source and build it for your use case.
@@ -117,7 +117,7 @@ If you have tried this and are still having trouble please reach out to us and w
 ## Documentation
 
 Documentation is available at
-[github.io](https://allencellmodeling.github.io/aicspylibczi).
+[github.io](https://bioio-devs.github.io/aicspylibczi).
 
 ## Build
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,66 +1,71 @@
 # AICSPyLibCZI Roadmap
 
-## For 3.* Releases 
+## For 3.\* Releases
+
 The `aicspylibczi` roadmap captures current development priorities within the project
 and should serve as a guide for core developers, to encourage contribution for new
 contributors, to provide insight to external developers who are interested in using
-`aicspylibczi` in their work, and to provide deeper insights to developers using 
+`aicspylibczi` in their work, and to provide deeper insights to developers using
 `aicsimageio` which uses this library to read ZEISSRAW format CZI files.
 
-The *mission* of `aicspylibczi` is to provide a robust method of access to Zeiss's 
-CZI microscopy files. Our approach is to use Zeiss's libCZI and leverage that to 
+The _mission_ of `aicspylibczi` is to provide a robust method of access to Zeiss's
+CZI microscopy files. Our approach is to use Zeiss's libCZI and leverage that to
 create a C++ tool that extracts the desired image data and metadata in a structure
 that performs well with respect to speed and memory usage and enables mapping into
-a python numpy.ndarray. The bindings to create a python module are done using 
+a python numpy.ndarray. The bindings to create a python module are done using
 pybind11 and are then wrapped in python class providing a more pythonic interface
 into the module that the direct bindings.
 
-Our goal with the 3.* API changes is:
- 
- * Unify the function/property naming conventions
- * Modify the library to support sAmples, the A dimension for RGB/BGR images
- * Enable reading of attachment data
- * Provide sufficient information to enable `aicspylibczi` to load a mosaic image as a dask.ndarray
- * Enable automated benchmark scripts
+Our goal with the 3.\* API changes is:
+
+- Unify the function/property naming conventions
+- Modify the library to support sAmples, the A dimension for RGB/BGR images
+- Enable reading of attachment data
+- Provide sufficient information to enable `aicspylibczi` to load a mosaic image as a dask.ndarray
+- Enable automated benchmark scripts
 
 ## Unify the function/property naming conventions
-Before 3.* it was pointed out the interface was a bit inconsistent. We attempt to address
+
+Before 3.\* it was pointed out the interface was a bit inconsistent. We attempt to address
 that here by using only bounding boxes and providing matched methods specific for non-mosaic
 images and mosaic images.
 
 ## Modify the library to support Samples, the A channel for RGB/BGR images
-For RGB (BGR) images the 3.* creates a new return dimension `A` which has size 3.
+
+For RGB (BGR) images the 3.\* creates a new return dimension `A` which has size 3.
 This was changed from expanding them out as additional channels because that was
-fraught with complications. It should be noted that in `aicsimageio` 4.* `S` stands 
+fraught with complications. It should be noted that in `aicsimageio` 4.\* `S` stands
 for `Samples` but because in `aicspylibczi` `S` is used for `Scene` so `A` is used
 to represent `sAmples`.
 
 ## Enable reading of attachment data
-Attachments can be embedded in subblocks along with the image. This data can take 
+
+Attachments can be embedded in subblocks along with the image. This data can take
 numerous forms, a small jpeg, datetime values, etc. Retrieval of this information
-will be implemented after the initial release. 
+will be implemented after the initial release.
 
 ## Provide enable dask friendly tile reconstruction for mosaic files.
+
 `aicsimageio` leverages dask to enable working with very large images.
 Mosaic files are often problematic in this regard. Though `aicspylibczi`
-can reconstruct mosaics but because they are so large there are cases 
-where something better is required. The tile information and individual 
-tile reading will be using in `aicsimageio` to create an `dask.ndarray` 
-which can be operated on like other dask objects enabling handling of 
+can reconstruct mosaics but because they are so large there are cases
+where something better is required. The tile information and individual
+tile reading will be using in `aicsimageio` to create an `dask.ndarray`
+which can be operated on like other dask objects enabling handling of
 truely huge mosaic images with `aicsimageio`
 
-
 ## Enable automated benchmark scripts
-Scripts exist to perform benchmarking but they do not currently utilize 
+
+Scripts exist to perform benchmarking but they do not currently utilize
 quilt for large files and can thus only be run locally. We would like to
 change this to be more like `aicsimageio` so that benchmarking can be added
 as a GitHub Action. This will not be in the initial 3.0 release but will
 come later.
 
-
 ## About This Document
+
 This document is meant to be a snapshot or high-level objectives and reasoning for the
-library during our 3.* series of releases. 
+library during our 3.\* series of releases.
 
 For more low-level implementation details, features, bugs, documentation requests, etc,
-please see our [issue tracker](https://github.com/AllenCellModeling/aicspylibczi/issues).
+please see our [issue tracker](https://github.com/bioio-devs/aicspylibczi/issues).

--- a/_aicspylibczi/exceptions.h
+++ b/_aicspylibczi/exceptions.h
@@ -17,7 +17,8 @@ class FilePtrException : public std::runtime_error
 public:
   explicit FilePtrException(const std::string& message_)
     : std::runtime_error("File Pointer Exception: " + message_)
-  {}
+  {
+  }
 };
 
 class PixelTypeException : public std::runtime_error
@@ -56,7 +57,8 @@ public:
   ImageAccessUnderspecifiedException(size_t given_, size_t required_, const std::string& message_)
     : std::runtime_error("Dimensions underspecified, given " + std::to_string(given_) + " dimensions but " +
                          std::to_string(required_) + " needed! \n\t" + message_)
-  {}
+  {
+  }
 };
 
 class ImageIteratorException : public std::runtime_error
@@ -64,7 +66,8 @@ class ImageIteratorException : public std::runtime_error
 public:
   explicit ImageIteratorException(const std::string& message_)
     : std::runtime_error("ImageIteratorException: " + message_)
-  {}
+  {
+  }
 };
 
 class ImageSplitChannelException : public std::runtime_error
@@ -74,7 +77,8 @@ public:
     : std::runtime_error("ImageSplitChannelExcetion: " + message_ +
                          " Channel should be zero or unset but has a value of " + std::to_string(channel_) +
                          " not sure how to procede in assigning channels.")
-  {}
+  {
+  }
 };
 
 class ImageCopyAllocFailed
@@ -103,7 +107,8 @@ public:
     : std::runtime_error("The coordinates are overspecified = you have specified a Dimension "
                          "or Dimension value that is not valid. " +
                          message_)
-  {}
+  {
+  }
 };
 
 class CDimCoordinatesUnderspecifiedException : public std::runtime_error // std::exception
@@ -113,7 +118,8 @@ public:
     : std::runtime_error("The coordinates are underspecified = you have not specified a "
                          "Dimension that is required. " +
                          message_)
-  {}
+  {
+  }
 };
 
 class CdimSelectionZeroImagesException : public std::runtime_error
@@ -136,11 +142,12 @@ class StrideAssumptionException : public std::runtime_error
 public:
   explicit StrideAssumptionException(const std::string& message_)
     : std::runtime_error("Image Stride % Width != 0 and/or Stride < Width. Please create an issue at \n"
-                         "https://github.com/AllenCellModeling/aicspylibczi \n"
+                         "https://github.com/bioio-devs/aicspylibczi \n"
                          "your file represents a case I didn't realized existed.\n"
                          "If you can share the file that would be exceptionally helpful. Thank you!\n" +
                          message_)
-  {}
+  {
+  }
 };
 
 class IsMosaicException : public std::runtime_error
@@ -148,7 +155,8 @@ class IsMosaicException : public std::runtime_error
 public:
   explicit IsMosaicException(const std::string& message_)
     : std::runtime_error("This file is a mosaic file but was assumed not to be. " + message_)
-  {}
+  {
+  }
 };
 
 class IsNotMosaicException : public std::runtime_error
@@ -156,7 +164,8 @@ class IsNotMosaicException : public std::runtime_error
 public:
   explicit IsNotMosaicException(const std::string& message_)
     : std::runtime_error("This file is not a mosaic file but was assumed to be. " + message_)
-  {}
+  {
+  }
 };
 
 class SceneIndexException : public std::runtime_error

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -32,7 +32,7 @@ You can either clone the public repository:
 
 .. code-block:: console
 
-    $ git clone --recurse-submodules https://github.com/AllenCellModeling/aicspylibczi
+    $ git clone --recurse-submodules https://github.com/bioio-devs/aicspylibczi
     $ git checkout release/aicspylibczi
 
 Once you have a copy of the source, you can install it with:
@@ -42,5 +42,5 @@ Once you have a copy of the source, you can install it with:
     $ python setup.py install
 
 
-.. _Github repo: https://github.com/AllenCellModeling/aicspylibczi
-.. _tarball: https://github.com/AllenCellModeling/aicspylibczi/tarball/master
+.. _Github repo: https://github.com/bioio-devs/aicspylibczi
+.. _tarball: https://github.com/bioio-devs/aicspylibczi/tarball/master

--- a/setup.py
+++ b/setup.py
@@ -64,66 +64,78 @@ extra_requirements = {
         *test_requirements,
         *setup_requirements,
         *dev_requirements,
-        *interactive_requirements
-    ]
+        *interactive_requirements,
+    ],
 }
 
 
 class CMakeExtension(Extension):
-    def __init__(self, name, sourcedir=''):
+    def __init__(self, name, sourcedir=""):
         Extension.__init__(self, name, sources=[])
         self.sourcedir = os.path.abspath(sourcedir)
 
 
 class CMakeBuild(build_ext):
     def build_extension(self, ext):
-        path_var = os.environ.get('PATH')
-        path_var = str(Path(sys.executable).parent) + ':' + path_var
+        path_var = os.environ.get("PATH")
+        path_var = str(Path(sys.executable).parent) + ":" + path_var
         env = dict(os.environ.copy(), PATH=path_var)
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
-        cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
-                      '-DPYTHON_EXECUTABLE=' + sys.executable]
+        cmake_args = [
+            "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
+            "-DPYTHON_EXECUTABLE=" + sys.executable,
+        ]
 
-        cfg = 'Debug' if self.debug else 'Release'
-        build_args = ['--config', cfg]
+        cfg = "Debug" if self.debug else "Release"
+        build_args = ["--config", cfg]
 
         if platform.system() == "Windows":
-            cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
-            cmake_args += ['-DCMAKE_GENERATOR_PLATFORM=x64']
-            build_args += ['--', '/m']
+            cmake_args += [
+                "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}".format(cfg.upper(), extdir)
+            ]
+            cmake_args += ["-DCMAKE_GENERATOR_PLATFORM=x64"]
+            build_args += ["--", "/m"]
         else:
-            cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
-            build_args += ['--', '-j2']
+            cmake_args += ["-DCMAKE_BUILD_TYPE=" + cfg]
+            build_args += ["--", "-j2"]
 
-        env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
-                                                              self.distribution.get_version())
+        env["CXXFLAGS"] = '{} -DVERSION_INFO=\\"{}\\"'.format(
+            env.get("CXXFLAGS", ""), self.distribution.get_version()
+        )
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
-        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
-        subprocess.check_call(['cmake', '--build', '.', '--target', '_aicspylibczi'] + build_args, cwd=self.build_temp, env=env)
+        subprocess.check_call(
+            ["cmake", ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env
+        )
+        subprocess.check_call(
+            ["cmake", "--build", ".", "--target", "_aicspylibczi"] + build_args,
+            cwd=self.build_temp,
+            env=env,
+        )
+
 
 setup(
-    name='aicspylibczi',
+    name="aicspylibczi",
     # Do not edit this string manually, always use bumpversion
     # Details in CONTRIBUTING.md
-    version='3.3.1',
-    author='Jamie Sherman, Paul Watkins',
-    author_email='jamies@alleninstitute.org, pwatkins@gmail.com',
-    description='A python module and a python extension for Zeiss (CZI/ZISRAW) microscopy files.',
+    version="3.3.1",
+    author="Jamie Sherman, Paul Watkins",
+    author_email="jamies@alleninstitute.org, pwatkins@gmail.com",
+    description="A python module and a python extension for Zeiss (CZI/ZISRAW) microscopy files.",
     long_description=readme,
     long_description_content_type="text/markdown",
     include_package_data=True,
     keywords="aicspylibczi, allen cell, imaging, computational biology",
     license="GPL-3.0-or-later",
     classifiers=[],
-    ext_modules=[CMakeExtension('_aicspylibczi')],
-    packages=['aicspylibczi'],
+    ext_modules=[CMakeExtension("_aicspylibczi")],
+    packages=["aicspylibczi"],
     cmdclass=dict(build_ext=CMakeBuild),
     install_requires=requirements,
     setup_requires=setup_requirements,
-    test_suite='aicspylibczi/tests',
+    test_suite="aicspylibczi/tests",
     tests_require=test_requirements,
     extras_require=extra_requirements,
-    url="https://github.com/AllenCellModeling/aicspylibczi",
+    url="https://github.com/bioio-devs/aicspylibczi",
     zip_safe=False,
 )


### PR DESCRIPTION
intention here is to replace `AllenCellModeling` with `bioio-devs` after migration.   
Files also got autoformatted, replacing single quote with double quote, and some whitespace cleanups.